### PR TITLE
Add kind override for Anomalous Bread

### DIFF
--- a/gamedata/configs/sortingplus.ltx
+++ b/gamedata/configs/sortingplus.ltx
@@ -66,6 +66,7 @@ killer_patch        = faction_patch
 renegade_patch      = faction_patch
 isg_patch           = faction_patch
 greh_patch          = faction_patch
+af_misery_bread     = i_arty
 
 ; this section describes the catagories used in the second half of the AMCM menu. This section is for modders to add new item types added by 
 ;		thier mod to the existing catagories or even add new ones. When adding new catagories you must make translation strings in 


### PR DESCRIPTION
Anomalous Bread (af_misery_bread) does not have a "kind" entry, which causes it to be sorted at the very bottom of the inventory. This fix moves the bread next to other artifacts.