### PR TITLE
Enable NPC loot inventory to be sorted on init.

### DIFF
--- a/gamedata/scripts/zzz_rax_sortingplus_mcm.script
+++ b/gamedata/scripts/zzz_rax_sortingplus_mcm.script
@@ -509,3 +509,36 @@ function ui_inventory.UIInventory:SortJunkTrade()
         db.actor:iterate_inventory(itr, db.actor)
     end
 end
+
+local snd_open = sound_object([[interface\inv_open]])
+
+-- Loot mode (Override)
+function ui_inventory.UIInventory.LMode_Init(self, obj)
+    self:Print(nil, "LMode_Init | obj: %s", obj and obj:name())
+
+    self.mode = "loot"
+
+    -- Show/Hide needed elements
+    self:Reset(obj)
+
+    -- We need this because box can spawn items after opening, so they don't update those instantly
+    if (not self.box_init_update.state) then -- Do not ignore inventory reset for npc boxes, so they are sorted on startup - Ishy.
+        self.box_init_update.tg = time_global()
+        self.box_init_update.state = true
+        self:LMode_ResetInventories(true)
+        return
+    end
+    self.box_init_update.state = false
+
+    -- Update inventories
+    self:LMode_ResetInventories()
+
+    -- Update info
+    self:UpdateInfo(true)
+
+    -- Known info (Special case for corpses)
+    self:LMode_TransferInfo(obj)
+
+    -- Sound effect
+    self:PlaySND(snd_open)
+end


### PR DESCRIPTION
In short: When looting a corpse, the left side inventory is first shown unsorted. To sort items, you have to refresh manually. This change fixes the problem. I have played an entire storyline with this and there seems to be no negative effects.

For some reason, vanilla UIInventory.LMode_Init function has an exception for NPC loot boxes (corpses) that prevents inventory reset on startup. Skipping or executing this reset seems to have no effect, but it prevents SortingPlus to do its thing when the loot screen comes up. If you want the NPC loot to be sorted, you either have to refresh the inventory (F5) or close and reopen the loot screen.

Well, not anymore. Removing the (seemingly unnecessary) check for npc_box enables SortingPlus to sort loot views like the others so npc loot is not all over the place when first seen.