### PR TITLE
Add keep limits, stock up, per-kind MCM, and sort enhancements

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,224 @@
+# dukaci - SortingPlus
+
+Patches for `110- SortingPlus - RavenAscendant`.
+
+## Features
+
+1. **Favorites sort to top by kind** — favorited items form their own category, optionally grouped by kind (weapons with weapons, food with food) or all in one row
+2. **Per-item keep limits on Put All** — right-click a favorited item → set limit → Put All deposits excess. Splits ammo stacks and multiuse items at the boundary. Persists across saves
+7. **Stock Up button** — appears next to Take All on stash containers. Takes favorited items from container to fill up to each keep limit. Splits ammo/multiuse at the boundary. Only shows on stash containers (not corpses/companions)
+3. **Per-kind MCM sort order** — each category has a configurable sort value with optional within-row priority (decimal part)
+4. **Junk category** — mark items as junk, sort to end, highlight/icon separately
+5. **Context menu** — toggle favorites/junk via right-click (if functors enabled)
+6. **ARM magazine support** — loaded magazines get their own sort category
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `gamedata/scripts/zzz_rax_sortingplus_mcm.script` | MCM menu builder, sort comparators, settings loader, FindFreeCell override |
+| `gamedata/scripts/zzzz_rax_sortingplus_keepcaps.script` | Keep-limit logic for Put All + Stock Up button |
+| `gamedata/scripts/rax_dynamic_custom_functor.script` | Right-click menu support |
+| `gamedata/scripts/rax_icon_layers.script` | Dynamic icon layer rendering |
+| `gamedata/scripts/rax_persistent_highlight.script` | Persistent cell coloring |
+| `gamedata/configs/sortingplus.ltx` | Sort defaults, groups, overrides, within-kind priority |
+| `gamedata/configs/ui/ui_sp_keepcaps.xml` | Keep-limit dialog + Stock Up button layout |
+| `gamedata/configs/text/eng/ui_st_sortingplus_unique.xml` | English MCM strings |
+| `gamedata/configs/text/eng/ui_st_sp_keepcaps.xml` | Keep-limit + Stock Up strings (eng) |
+| `gamedata/configs/text/rus/ui_st_sp_keepcaps.xml` | Keep-limit + Stock Up strings (rus) |
+| `gamedata/configs/text/rus/ui_st_sortingplus_unique.xml` | Russian MCM strings |
+| `gamedata/textures/ui/sortingplus/icon-favourite.dds` | Favorite marker overlay |
+| `gamedata/textures/ui/sortingplus/icon-junk.dds` | Junk marker overlay |
+
+## Architecture
+
+### MCM Menu (`on_mcm_load`)
+
+Built dynamically:
+1. Reads kind defaults from `[sortingplus_kind_defaults]` in LTX
+2. Reads display groups from `[sortingplus_kind_groups]` in LTX (ordered)
+3. Scans `ini_sys` for undiscovered kinds → adds to "Discovered" group
+4. Generates widgets: title per group, number input per kind
+
+Labels resolved by MCM via `ui_mcm_SortingPlus_<id>` string lookup — no hooks.
+
+### Sort Value System
+
+Each item category has a numeric sort value (e.g. `2.1`):
+- **Whole number** = row group (same number = same inventory row)
+- **Decimal** = position within that row (2.1 before 2.2)
+- `subkindprio` toggle: when OFF, `math.floor()` flattens values so decimals are ignored
+
+### Sort Comparators
+
+Five functions override `utils_ui`:
+
+| Function | Primary sort | Fallback |
+|----------|-------------|----------|
+| `sort_by_kind` | Kind value | Size |
+| `sort_by_sizekind` | Width → height | Kind → within-kind priority → alpha → condition |
+| `sort_by_size` | Within-kind priority | Width → height → alpha |
+| `sort_by_props` | Same-section only: ammo count → upgrades → condition |
+| `sort_by_index` | Index-based |
+
+### FindFreeCell Override
+
+Tracks kind-based row separation in `sort_method == "kind"`:
+- Favorites with `FAVSKINDROWS`: sort order = `-1000 - kind_value` (above all, keeps kind separation)
+- Favorites without kind rows: sort order = `-1000` (single row)
+- Compares integer parts to detect kind change → starts new row
+
+### Settings (`loadsettings`)
+
+Called on MCM change. Clears caches (`item_order`, `ab_k`, `item_sort_prio`, `kind_overrides`). Rebuilds sort order from either LTX (`useltx`) or MCM inputs. Applies `math.floor()` if `subkindprio` is off.
+
+### Keep Limits (Put All Override)
+
+1. Pre-scan actor inventory for favorited items with limits
+2. Group by section, sort by condition then units
+3. Accumulate greedily; mark excess for deposit
+4. Call original Put All
+5. Split border items: trim kept units, create new item with excess in NPC stash
+6. Excludes artefact melter (`itm_artefactskit`) from splitting
+
+### Stock Up Button
+
+Monkey-patches `InitControls`, `InitCallbacks`, and `Reset` on `UIInventory`:
+1. Shrinks Take All to 90px, adds Stock Up button (90px) to its right
+2. Only visible on stash containers (`npc_is_box`), not corpses or companions
+3. `LMode_StockUp` — inverse of Put All:
+   - Count player units per favorited+limited section
+   - Calculate deficit (limit − player count)
+   - Scan container for matching items, sort best condition first
+   - Take greedily; split ammo/multiuse at boundary (same exclusions as Put All)
+   - Sections with no explicit limit (nil = "keep all") are skipped
+
+### Highlighting & Icons
+
+- `rax_persistent_highlight`: favorites = green (`ARGB 50,176,238,26`), junk = red (`ARGB 50,204,0,0`)
+- `rax_icon_layers`: overlays 15x15 icons (top-left for favorites, top-right for junk)
+
+### Keybinds
+
+- `K` (DIK_K): Toggle favorite
+- `J` (DIK_J): Toggle junk
+
+## MCM Settings
+
+| ID | Type | Default | Description |
+|----|------|---------|-------------|
+| `hilitefavs` | check | true | Highlight favorited items |
+| `iconfavs` | check | true | Show favorite marker icon |
+| `sortfavs` | check | true | Favorites as separate sort category |
+| `favskindrows` | check | true | Favorites grouped by kind (vs single row) |
+| `putallfavs` | check | true | Block Put All for favorites |
+| `hilitejunk` | check | true | Highlight junk items |
+| `iconjunk` | check | true | Show junk marker icon |
+| `sortjunk` | check | true | Junk as separate sort category |
+| `selljunk` | check | true | Auto-move junk to trade pane |
+| `playerinv` | check | true | Sort player inventory |
+| `playertrade` | check | true | Sort player trade inventory |
+| `npcinv` | check | true | Sort NPC/container inventory |
+| `npctrade` | check | true | Sort NPC trade inventory |
+| `resort` | check | false | Re-sort immediately on mark |
+| `usefunctors` | check | true | Right-click menu for favorites/junk |
+| `useltx` | check | false | Use LTX sort order instead of MCM inputs |
+| `subkindprio` | check | true | Within-row priority (decimal part matters) |
+
+Plus dynamic per-kind number inputs (`ko_<kind>`) built from LTX defaults.
+
+## LTX Sections (`sortingplus.ltx`)
+
+| Section | Purpose |
+|---------|---------|
+| `[item_kind_order]` | Legacy sort order (used when `useltx` checked) |
+| `[kind_overrides]` | Force items into different kinds (+ automatic prefix splits: `prt_w_*` → `i_part_w`, `prt_o_*` → `i_part_o`) |
+| `[item_sort_priority]` | Within-kind ordering for individual items (lower = first, default 1000) |
+| `[sortingplus_kind_defaults]` | Default sort value per kind (populates MCM inputs) |
+| `[sortingplus_kind_groups]` | Display grouping for MCM UI (order = display order) |
+
+## Adding a New Kind / MCM Group
+
+No script changes needed — the system is fully data-driven.
+
+### 1. Register the kind in `sortingplus.ltx`
+
+Add an entry to each of these sections:
+
+```ini
+[item_kind_order]
+my_new_kind = 15
+
+[sortingplus_kind_defaults]
+my_new_kind = 15
+```
+
+To put it in an existing group, append it to that group's line in `[sortingplus_kind_groups]`:
+
+```ini
+[sortingplus_kind_groups]
+grp_equipment = i_device,i_tool,i_repair,i_kit,my_new_kind
+```
+
+To create a new group, add a new line (position in the section = position in MCM):
+
+```ini
+[sortingplus_kind_groups]
+grp_mygroup = my_new_kind,another_kind
+```
+
+### 2. Add XML strings
+
+In `ui_st_sortingplus_unique.xml` (both `eng/` and `rus/`):
+
+```xml
+<!-- Group header (only if adding a new group) -->
+<string id="ui_mcm_SortingPlus_grp_mygroup">
+    <text>My Group</text>
+</string>
+
+<!-- Kind label (shown next to the number input) -->
+<string id="ui_mcm_SortingPlus_ko_my_new_kind">
+    <text>My New Kind</text>
+</string>
+
+<!-- Kind tooltip (shown on hover) -->
+<string id="ui_mcm_SortingPlus_ko_my_new_kind_desc">
+    <text>Description of what this kind contains.</text>
+</string>
+```
+
+### String ID convention
+
+| Element | Pattern |
+|---------|---------|
+| Group header | `ui_mcm_SortingPlus_` + group id (e.g. `grp_mygroup`) |
+| Kind label | `ui_mcm_SortingPlus_ko_` + kind name |
+| Kind tooltip | `ui_mcm_SortingPlus_ko_` + kind name + `_desc` |
+
+### Auto-discovery fallback
+
+If a mod adds items with a `kind` value not in `[sortingplus_kind_defaults]`, the script discovers it at runtime by scanning `ini_sys`, assigns default sort value `30`, and appends it to a "Discovered" group at the bottom of MCM. It works without config — it just won't have a nice label.
+
+## Global State
+
+| Variable | Purpose |
+|----------|---------|
+| `item_order` | kind → sort value (float) |
+| `kind_overrides` | section → overridden kind |
+| `item_sort_prio` | section → within-kind priority |
+| `favorite_itms` | section → "favorites" (persisted) |
+| `junk_itms` | section → "junk" (persisted) |
+| `favorite_limits` | section → keep count (persisted, in loadout limits script) |
+| `ab_w`, `ab_h`, `ab_k` | item dimension/kind caches |
+
+## Callbacks
+
+| Callback | Purpose |
+|----------|---------|
+| `load_state` / `save_state` | Persist favorites, junk marks, keep limits |
+| `actor_on_first_update` | Initial settings load |
+| `on_option_change` | MCM change → reload settings |
+| `ActorMenu_on_item_before_move` | Block favorites from Put All, allow excess deposits |
+| `GUI_on_show` | Auto-move junk to trade pane |
+| `on_key_press` | K/J keybinds |

--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
-# SortingPlus
-Reenables categorized grouping of items in the inventory screens.
-Optional AMCM support allows for selecting which screens. Get AMCM here.
+dukaci - SortingPlus
+Patches for SortingPlus by RavenAscendant.
 
-I say reenable because Tronex built this system in ui_inventory and then commented out the lines that would have enabled it. I just set those flags.
+Requires: 110- SortingPlus - RavenAscendant
+Place below SortingPlus in MO2 load order.
 
-SortingPlus now adds additional original features providing sorting control beyond that available in the built in code.
+Changes:
 
-sortingplus.ltx now controls the sorting order and groups when not using AMCM or when "Use sortingplus.ltx" is selected in AMCM. AMCM also has less granular in game method for adjusting sorting order and groups. (35 categories in ltx combined down to 15 in AMCM menu)
+1. Favorites sort to top of inventory grid, grouped by kind.
+   Stock behavior lumps all favorites into one flat group.
+   This keeps weapons with weapons, food with food, etc.
+   Modified: zzz_rax_sortingplus_mcm.script (FindFreeCell)
 
-Hovering the mouse over an item and pressing the K key will cause it to be added to a list of favorited items. Favorited items can be prevented from transferring when the Put all Button is used.
-
-Hovering the mouse over an item and pressing the J key will cause it to be added to a list of junk items. Junk items can be set to automatically move to the selling window of traders that will buy them.
-
-Items in these list are treated as if in a category together. that category's position in the list can be adjusted just like the other categories via AMCM or the LTX. Defaults to the top of the list for favorites, bottom for junk. Color highlighting no longer requires another mod.
-
-Favorites/Junk are stored by section. What this means is that an AN-94 is not the same as an AN-94 with a scope on it. If you add attachments you will need to re-favorite your gun, but only once for each configuration.
-
-Curtesy of Ishmaeel sortingplus.ltx now has a section offering item by item kind override. This can be used to move an item from one category to another when you don't agree with the original classification.
+2. Per-item keep limits on Put All.
+   Right-click a favorited item -> "Keep Limit" -> enter a number.
+   Put All then keeps only that many units and deposits the rest.
+   Handles ammo stack splitting and multiuse item splitting.
+   Limits persist across saves.
+   Files: zzzz_rax_sortingplus_keepcaps.script,
+          ui_sp_keepcaps.xml,
+          ui_st_sp_keepcaps.xml

--- a/gamedata/configs/sortingplus.ltx
+++ b/gamedata/configs/sortingplus.ltx
@@ -1,47 +1,51 @@
-
 ;Change this table to change how things are sorted when not using AMCM or when "Use sortingplus.ltx" is checked in the AMCM menu.
 
 [item_kind_order]
 favorites           = -2 ;custom category items set to via key bind
 loadout				= -1 ;support for ARM
 mags				= 0  ;support for ARM
-w_sniper            = 1 
-w_rifle             = 1 
-w_smg               = 1
-w_shotgun           = 1 
-w_pistol            = 1 
-w_melee             = 1
-w_misc              = 1
-w_base              = 1
-w_explosive         = 1
-o_heavy             = 2 
-o_sci               = 2 
-o_medium            = 2 
-o_light             = 2 
-o_helmet            = 2
-i_arty              = 3
-i_arty_junk         = 3
-i_arty_cont         = 3
-i_device            = 4
-i_tool              = 5
-i_repair            = 5
-i_kit               = 5
-i_backpack          = 5
-i_medical           = 6
-i_food              = 7
-i_drink             = 7
-i_mutant_cooked     = 7
-i_mutant_raw        = 7
-i_letter            = 8
-i_quest             = 8
-w_ammo              = 9
-i_mutant_belt       = 10
-i_mutant_part       = 10
-i_misc              = 11
-i_upgrade           = 12
-i_part              = 13
-faction_patch       = 14
-junk                = 100 ;custom category items set to via key bind
+i_medical           = 1.1
+tobacco             = 1.2
+i_drink             = 1.3
+i_food              = 1.4
+i_mutant_cooked     = 1.5
+i_attach            = 2.1
+i_mutant_belt       = 2.2
+i_arty              = 2.3
+i_arty_cont         = 2.4
+i_arty_junk         = 2.5
+i_device            = 3
+i_repair            = 3.1
+i_tool              = 3.2
+i_misc              = 4
+w_sniper            = 4.1
+w_rifle             = 4.2
+w_smg               = 4.3
+w_shotgun           = 4.4
+w_pistol            = 4.5
+w_melee             = 4.6
+w_misc              = 5
+w_base              = 6
+w_explosive         = 6.1
+o_heavy             = 7
+o_medium            = 7
+o_sci               = 7
+o_light             = 7
+o_helmet            = 7
+i_backpack          = 7
+i_kit               = 7
+w_ammo              = 10
+i_mutant_part       = 11.1
+i_mutant_raw        = 11.2
+i_part_w            = 13.1
+i_part_o            = 13.2
+i_part              = 13.3
+w_ammo_parts        = 13.4
+i_upgrade           = 13.5
+i_letter            = 99
+i_quest             = 99
+faction_patch       = 999
+junk                = 1000 ;custom category items set to via key bind
 
 ;You can force some items to be sorted as a different "kind" so they are grouped together with other items with perceived similarity.
 ;Below are some opinionated defaults. If you add a brand new "kind" entry, (like "faction_patch") be sure to also add it to [item_kind_order] section above.
@@ -54,8 +58,6 @@ bad_psy_helmet      = i_device
 decoder             = i_device
 attackers_pda       = i_device
 contact_lost_pda    = i_device
-decryption_radio    = i_device
-zat_b40_sarge_pda   = i_device
 lead_box            = i_tool
 csky_patch          = faction_patch
 dolg_patch          = faction_patch
@@ -70,28 +72,451 @@ renegade_patch      = faction_patch
 isg_patch           = faction_patch
 greh_patch          = faction_patch
 af_misery_bread     = i_arty
+bullet_pistol       = w_ammo_parts
+bullet_pistol_ap    = w_ammo_parts
+bullet_r5           = w_ammo_parts
+bullet_r5_ap        = w_ammo_parts
+bullet_r7           = w_ammo_parts
+bullet_r7_ap        = w_ammo_parts
+bullet_shotgun      = w_ammo_parts
+bullet_shotgun_ap   = w_ammo_parts
+casing_p            = w_ammo_parts
+casing_r5           = w_ammo_parts
+casing_r7           = w_ammo_parts
+casing_s            = w_ammo_parts
+powder_1            = w_ammo_parts
+powder_2            = w_ammo_parts
+powder_3            = w_ammo_parts
+weapon_ammo_parts   = w_ammo_parts
+cigarettes          = tobacco
+cigarettes_lucky    = tobacco
+cigarettes_russian  = tobacco
+cigar               = tobacco
+cigar1              = tobacco
+cigar2              = tobacco
+cigar3              = tobacco
+tobacco             = tobacco
+hand_rolling_tobacco = tobacco
 
-; this section describes the catagories used in the second half of the AMCM menu. This section is for modders to add new item types added by 
-;		thier mod to the existing catagories or even add new ones. When adding new catagories you must make translation strings in 
-;		configs/text/eng and configs/text/rus see existing strings for formatting. The leading number is the default value, position in the list
-;		equates to position. NO WHITE SPACE!
-[sortingplusmcm]
-000favorites      = -2,favorites;custom category items set to via key bind
-001loadout		  = -1,loadout;support for ARM
-002mags		 	  = 0,mags;support for ARM
-010weapons        = 1,w_sniper,w_rifle,w_smg,w_shotgun,w_pistol,w_melee,w_misc,w_base,w_explosive
-020outfits        = 2,o_heavy,o_sci,o_medium,o_light,o_helmet,i_backpack
-030artifacts      = 3,i_arty,i_arty_junk,i_arty_cont
-040devices        = 4,i_device
-050tools          = 5,i_tool,i_repair,i_kit
-060medical        = 6,i_medical
-070foods          = 7,i_food,i_drink,i_drink
-080mutantfoods    = 7,i_mutant_cooked,i_mutant_raw
-090quest          = 8,i_quest
-100notes          = 8,i_letter
-110ammo           = 9,w_ammo
-120mutantparts    = 10,i_mutant_belt,i_mutant_part
-130misc           = 11,i_misc
-140upgrades       = 12,i_upgrade
-150parts          = 13,i_part
-999junk           = 100,junk;custom category items set to via key bind
+;Within-kind sort priority. Values encode kind group and position: kind_number * 100 + item_position.
+;Items not listed here get a default priority of 1000 and sort by size/name as before.
+[item_sort_priority]
+;Medical (i_medical) — kind 1
+;Wound care
+bandage             = 101
+jgut                = 102
+survival_kit        = 103
+;Medkits
+medkit              = 104
+medkit_army         = 105
+medkit_scientic     = 106
+;Stimpacks
+stimpack            = 107
+stimpack_army       = 108
+stimpack_scientic   = 109
+rebirth             = 110
+;Quick heals
+drug_coagulant      = 111
+akvatab             = 112
+yadylin             = 113
+tetanus             = 114
+;Stimulants
+caffeine            = 115
+drug_booster        = 116
+cocaine             = 117
+adrenalin           = 118
+;Healing shots
+glucose_s           = 119
+glucose             = 120
+;Pain relief
+analgetic           = 121
+salicidic_acid      = 122
+morphine            = 123
+;Anti-radiation
+drug_radioprotector = 124
+antirad_cystamine   = 125
+antirad_kalium      = 126
+antirad             = 127
+;Anti-toxin / infection
+drug_antidot        = 128
+antibio_sulfad      = 129
+antibio_chlor       = 130
+;Psy / recreational / sleep
+joint               = 131
+marijuana           = 132
+drug_sleepingpills  = 133
+antiemetic          = 134
+drug_psy_blockade   = 135
+drug_anabiotic      = 136
+;Packages (bottom)
+medkit_ai1          = 137
+medkit_ai2          = 138
+medkit_ai3          = 139
+
+;Tobacco — kind 2
+cigarettes_russian  = 201
+cigar1              = 202
+cigarettes          = 203
+cigarettes_lucky    = 204
+cigar2              = 205
+cigar3              = 206
+cigar               = 207
+tobacco             = 208
+hand_rolling_tobacco = 209
+
+;Drinks (i_drink) — kind 3
+tea                 = 301
+mineral_water       = 302
+flask               = 303
+water_drink         = 304
+energy_drink        = 305
+coffee_drink        = 306
+drink_crow          = 307
+brewed_coffee       = 308
+bottle_metal        = 309
+vodka_quality       = 310
+vodka2              = 311
+vodka               = 312
+beer                = 313
+ground_coffee       = 314
+
+;Food (i_food) — kind 4
+mre                 = 401
+ration_ru           = 402
+ration_ukr          = 403
+beans               = 404
+chili               = 405
+corn                = 406
+tomato              = 407
+tushonka            = 408
+conserva            = 409
+nuts                = 410
+raisins             = 411
+mint                = 412
+protein             = 413
+chocolate           = 414
+chocolate_p         = 415
+bread               = 416
+breadold            = 417
+kolbasa             = 418
+sausage             = 419
+salmon              = 420
+
+;Cooked mutant food (i_mutant_cooked) — kind 5
+meat_tushkano       = 501
+meat_tushkano_b     = 502
+meat_tushkano_a     = 503
+meat_dog            = 504
+meat_dog_b          = 505
+meat_dog_a          = 506
+meat_pseudodog      = 507
+meat_pseudodog_b    = 508
+meat_pseudodog_a    = 509
+meat_flesh          = 510
+meat_flesh_b        = 511
+meat_flesh_a        = 512
+meat_boar           = 513
+meat_boar_b         = 514
+meat_boar_a         = 515
+meat_bloodsucker    = 516
+meat_bloodsucker_b  = 517
+meat_bloodsucker_a  = 518
+meat_snork          = 519
+meat_snork_b        = 520
+meat_snork_a        = 521
+meat_chimera        = 522
+meat_chimera_b      = 523
+meat_chimera_a      = 524
+meat_lurker         = 525
+meat_lurker_b       = 526
+meat_lurker_a       = 527
+meat_psysucker      = 528
+meat_psysucker_b    = 529
+meat_psysucker_a    = 530
+
+;Repair (i_repair) — kind 6
+;Armor repair kits
+exo_repair_kit      = 601
+heavy_repair_kit    = 602
+medium_repair_kit   = 603
+light_repair_kit    = 604
+helmet_repair_kit   = 605
+;Field armor toolkit
+heavy_sewing_thread = 606
+sewing_thread       = 607
+;Glue
+glue_e              = 608
+glue_a              = 609
+glue_b              = 610
+;Emergency
+armor_repair_fa     = 611
+;Sewing kits
+sewing_kit_h        = 612
+sewing_kit_a        = 613
+sewing_kit_b        = 614
+;Weapon repair kits (A→D)
+toolkit_p           = 615
+toolkit_s           = 616
+toolkit_r5          = 617
+toolkit_r7          = 618
+;Cleaning kits (A→D, then Universal)
+cleaning_kit_p      = 619
+cleaning_kit_s      = 620
+cleaning_kit_r5     = 621
+cleaning_kit_r7     = 622
+cleaning_kit_u      = 623
+;Sharpening
+sharpening_stones   = 624
+
+;Tools (i_tool) — kind 7
+leatherman_tool     = 701
+grooming            = 702
+swiss_knife         = 703
+;Batteries
+batteries_dead      = 704
+batteries_exo       = 705
+;Fire
+box_matches         = 706
+matches             = 707
+;Money
+roubles             = 708
+;Bolts
+bolts_pack          = 709
+
+;Misc (i_misc) — kind 8
+;Waste
+rotten_meat         = 801
+;Fuel
+kerosene            = 802
+explo_jerrycan_fuel_empty = 803
+explo_balon_gas_empty    = 804
+;Magazines
+porn                = 805
+porn2               = 806
+;Shovels
+shovel_mili         = 807
+shovel_old          = 808
+;Hand tools
+rasp_tool           = 809
+ramrod_tool         = 810
+ball_hammer         = 811
+steel_wool          = 812
+;Gun maintenance
+gun_oil             = 813
+gun_oil_ru          = 814
+gun_oil_ru_d        = 815
+solvent             = 816
+grease              = 817
+;Tools
+duct_tape           = 818
+welding_goggles     = 819
+mirror              = 820
+cutlery             = 821
+;Small containers
+e_syringe           = 822
+jar                 = 823
+;Rope
+synthrope           = 824
+rope                = 825
+;Fabric / clothing
+tarpaulin           = 826
+beadspread          = 827
+underwear           = 828
+gloves              = 829
+boots               = 830
+;Empty containers
+explo_metalcan_powder    = 831
+;Broken electronics
+flashlight_broken   = 832
+headlamp            = 833
+broken_detector     = 834
+walkie              = 835
+radio               = 836
+radio2              = 837
+;Entertainment / valuables
+jewelry_box         = 838
+cards               = 839
+picture_woman       = 840
+meinkampf           = 841
+
+;Kits (i_kit) — kind 9
+;Artefact Melter
+itm_artefactskit    = 901
+;Tools (increasing intensity)
+itm_basickit        = 902
+itm_advancedkit     = 903
+itm_expertkit       = 904
+;Specialty craft tools
+itm_ammokit         = 905
+itm_drugkit         = 906
+;Cooking
+fieldcooker         = 907
+cooking             = 908
+army_bowler         = 909
+itm_campfire        = 910
+;Camping
+itm_sleepbag        = 911
+compression_bag     = 912
+itm_tent            = 913
+itm_tent_bag        = 914
+
+;Weapon parts (i_part_w) — kind 10
+;Barrels (rifle)
+prt_w_barrel_1      = 1001
+prt_w_barrel_2      = 1002
+prt_w_barrel_3      = 1003
+prt_w_barrel_4      = 1004
+prt_w_barrel_5      = 1005
+prt_w_barrel_6      = 1006
+prt_w_barrel_7      = 1007
+prt_w_barrel_8      = 1008
+prt_w_barrel_9      = 1009
+prt_w_barrel_10     = 1010
+prt_w_barrel_11     = 1011
+prt_w_barrel_12     = 1012
+prt_w_barrel_13     = 1013
+;Barrels (pistol)
+prt_w_p_barrel_1    = 1014
+prt_w_p_barrel_2    = 1015
+prt_w_p_barrel_3    = 1016
+prt_w_p_barrel_4    = 1017
+prt_w_p_barrel_5    = 1018
+prt_w_p_barrel_6    = 1019
+prt_w_p_barrel_7    = 1020
+;Bolts
+prt_w_bolt_1        = 1021
+prt_w_bolt_2        = 1022
+prt_w_bolt_3        = 1023
+prt_w_bolt_4        = 1024
+prt_w_bolt_5        = 1025
+prt_w_bolt_6        = 1026
+prt_w_bolt_7        = 1027
+prt_w_bolt_8        = 1028
+prt_w_bolt_9        = 1029
+prt_w_bolt_10       = 1030
+prt_w_bolt_11       = 1031
+prt_w_bolt_12       = 1032
+prt_w_bolt_13       = 1033
+prt_w_bolt_14       = 1034
+prt_w_bolt_15       = 1035
+prt_w_bolt_16       = 1036
+prt_w_bolt_17       = 1037
+;Bolt carriers
+prt_w_bolt_carrier_1  = 1041
+prt_w_bolt_carrier_2  = 1042
+prt_w_bolt_carrier_3  = 1043
+prt_w_bolt_carrier_4  = 1044
+prt_w_bolt_carrier_5  = 1045
+prt_w_bolt_carrier_6  = 1046
+prt_w_bolt_carrier_7  = 1047
+prt_w_bolt_carrier_8  = 1048
+prt_w_bolt_carrier_9  = 1049
+prt_w_bolt_carrier_10 = 1050
+prt_w_bolt_carrier_11 = 1051
+;Gas tubes
+prt_w_gas_tube_1    = 1061
+prt_w_gas_tube_2    = 1062
+prt_w_gas_tube_3    = 1063
+prt_w_gas_tube_4    = 1064
+prt_w_gas_tube_5    = 1065
+prt_w_gas_tube_6    = 1066
+prt_w_gas_tube_7    = 1067
+prt_w_gas_tube_8    = 1068
+prt_w_gas_tube_9    = 1069
+prt_w_gas_tube_10   = 1070
+prt_w_gas_tube_11   = 1071
+;Springs (pistol)
+prt_w_p_spring_1    = 1081
+prt_w_p_spring_2    = 1082
+prt_w_p_spring_3    = 1083
+prt_w_p_spring_4    = 1084
+prt_w_p_spring_5    = 1085
+prt_w_p_spring_6    = 1086
+;Triggers (pistol)
+prt_w_p_trigger_1   = 1091
+prt_w_p_trigger_2   = 1092
+prt_w_p_trigger_3   = 1093
+prt_w_p_trigger_4   = 1094
+;Trigger components
+prt_w_trigger_components_1 = 1101
+prt_w_trigger_components_2 = 1102
+prt_w_trigger_components_3 = 1103
+prt_w_trigger_components_4 = 1104
+prt_w_trigger_components_5 = 1105
+prt_w_trigger_components_6 = 1106
+
+;General parts (i_part) — kind 11
+prt_i_capacitors    = 1101
+prt_i_transistors   = 1102
+prt_i_resistors     = 1103
+prt_i_fasteners     = 1104
+prt_i_copper        = 1105
+prt_i_scrap         = 1106
+prt_i_wood          = 1107
+
+; Default sort order for every kind. Each kind gets its own MCM input.
+; Same number = same row. Decimal part = within-row priority (14.1 before 14.2).
+[sortingplus_kind_defaults]
+favorites           = -2
+loadout             = -1
+mags                = 0
+i_medical           = 1.1
+tobacco             = 1.2
+i_drink             = 1.3
+i_food              = 1.4
+i_mutant_cooked     = 1.5
+i_attach            = 2.1
+i_mutant_belt       = 2.2
+i_arty              = 2.3
+i_arty_cont         = 2.4
+i_arty_junk         = 2.5
+i_device            = 3
+i_repair            = 3.1
+i_tool              = 3.2
+i_misc              = 4
+w_sniper            = 4.1
+w_rifle             = 4.2
+w_smg               = 4.3
+w_shotgun           = 4.4
+w_pistol            = 4.5
+w_melee             = 4.6
+w_misc              = 5
+w_base              = 6
+w_explosive         = 6.1
+o_armor             = 7
+o_heavy             = 7
+o_medium            = 7
+o_sci               = 7
+o_light             = 7
+o_helmet            = 7
+i_backpack          = 7
+i_kit               = 7
+w_ammo              = 10
+i_mutant_part       = 11.1
+i_mutant_raw        = 11.2
+i_part_w            = 13.1
+i_part_o            = 13.2
+i_part              = 13.3
+w_ammo_parts        = 13.4
+i_upgrade           = 13.5
+i_letter            = 99
+i_quest             = 99
+faction_patch       = 999
+junk                = 1000
+
+; Display groups for MCM UI. Order of groups = display order.
+; Each line: group_id = kind1,kind2,...
+[sortingplus_kind_groups]
+grp_special     = favorites,loadout,mags
+grp_weapons     = w_sniper,w_rifle,w_smg,w_shotgun,w_pistol,w_melee,w_misc,w_base,w_explosive
+grp_outfits     = o_armor,o_heavy,o_medium,o_sci,o_light,o_helmet,i_backpack
+grp_belt        = i_attach,i_arty,i_arty_junk,i_arty_cont,i_mutant_belt
+grp_equipment   = i_device,i_tool,i_repair,i_kit
+grp_consumables = i_medical,i_food,i_drink,i_mutant_cooked,tobacco
+grp_quest       = i_letter,i_quest
+grp_ammo        = w_ammo
+grp_mutant      = i_mutant_part,i_mutant_raw
+grp_misc        = i_misc,faction_patch
+grp_upgrades    = i_upgrade
+grp_parts       = i_part_w,i_part_o,i_part,w_ammo_parts
+grp_junk        = junk

--- a/gamedata/configs/text/eng/ui_st_sortingplus.xml
+++ b/gamedata/configs/text/eng/ui_st_sortingplus.xml
@@ -1,5 +1,8 @@
-<!-- 
-	Anomaly Modconfiguration Menu strings	
+<!--
+	Anomaly Modconfiguration Menu strings
+	Per-kind labels use "Category - Subcategory" (broadest to narrowest).
+	To add a custom kind: add ui_mcm_SortingPlus_ko_<kind> here
+	and optionally ui_mcm_SortingPlus_ko_<kind>_desc for tooltip.
 -->
 
 <string_table>
@@ -17,15 +20,14 @@
 		<text>UnMark Junk</text>
 	</string>
 
-
-
 	<string id="ui_mcm_title_SortingPlus">
 		<text>Sorting Plus</text>
 	</string>
-
 	<string id="ui_mcm_menu_SortingPlus">
 		<text>Sorting Plus</text>
 	</string>
+
+	<!-- Checkbox labels -->
 	<string id="ui_mcm_SortingPlus_playerinv">
 		<text>Sort Player Inventory</text>
 	</string>
@@ -54,9 +56,8 @@
 		<text>Use sortingplus.ltx</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_useltx_desc">
-		<text>Ignores settings below in favor of those in sortingplus.ltx which offers more granular control.</text>
+		<text>Ignores per-kind sort order inputs below in favor of [item_kind_order] in sortingplus.ltx.</text>
 	</string>
-
 	<string id="ui_mcm_SortingPlus_iconjunk">
 		<text>Mark Junk</text>
 	</string>
@@ -73,7 +74,7 @@
 		<text>Use Junk Category</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_sortjunk_desc">
-		<text>Sorts Junk items into thier own category, by default the last one.</text>
+		<text>Sorts Junk items into their own category, by default the last one.</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_selljunk">
 		<text>"Auto" Sell Junk</text>
@@ -99,6 +100,12 @@
 	<string id="ui_mcm_SortingPlus_sortfavs_desc">
 		<text>Sorts Favorites items into their own category, by default the first one.</text>
 	</string>
+	<string id="ui_mcm_SortingPlus_favskindrows">
+		<text>Favorites: Group by Kind</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_favskindrows_desc">
+		<text>ON: favorites keep their kind row separation (weapons row, food row, etc.). OFF: all favorites share a single row, sorted by priority.</text>
+	</string>
 	<string id="ui_mcm_SortingPlus_putallfavs">
 		<text>Block "Move all" for Favorites.</text>
 	</string>
@@ -111,64 +118,366 @@
 	<string id="ui_mcm_SortingPlus_resort_desc">
 		<text>Inventory will resort immediately when marking Favorites/Junk. Otherwise waits until next time inventory opened. Useful feedback if highlighting is disabled.</text>
 	</string>
+	<string id="ui_mcm_SortingPlus_usefunctors">
+		<text>Use Right-Click Functors</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_usefunctors_desc">
+		<text>Enable right-click menu entries for marking Favorites/Junk.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_subkindprio">
+		<text>Within-Row Priority</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_subkindprio_desc">
+		<text>Each category below has a sort number. The whole number sets the row group — categories with the same whole number share an inventory row (e.g. all weapons at 1). The decimal sets position within that row (e.g. 2.1 before 2.2). When this is OFF, decimals are ignored and all categories with the same whole number sort purely by item size.</text>
+	</string>
 
-	<string id="ui_mcm_SortingPlus_001loadout">
-		<text>ARM Loadout</text>
+	<!-- Group header titles (MCM section dividers) -->
+	<string id="ui_mcm_SortingPlus_grp_special">
+		<text>Special</text>
 	</string>
-	<string id="ui_mcm_SortingPlus_002mags">
-		<text>ARM Magazines</text>
-	</string>
-
-	<string id="ui_mcm_SortingPlus_000favorites">
-		<text>Favorites</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_999junk">
-		<text>Junk</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_010weapons">
+	<string id="ui_mcm_SortingPlus_grp_weapons">
 		<text>Weapons</text>
 	</string>
-	<string id="ui_mcm_SortingPlus_020outfits">
+	<string id="ui_mcm_SortingPlus_grp_outfits">
 		<text>Outfits</text>
 	</string>
-	<string id="ui_mcm_SortingPlus_030artifacts">
-		<text>Artifacts</text>
+	<string id="ui_mcm_SortingPlus_grp_belt">
+		<text>Belt</text>
 	</string>
-	<string id="ui_mcm_SortingPlus_040devices">
-		<text>Devices</text>
+
+	<string id="ui_mcm_SortingPlus_grp_equipment">
+		<text>Equipment</text>
 	</string>
-	<string id="ui_mcm_SortingPlus_050tools">
-		<text>Tools</text>
+	<string id="ui_mcm_SortingPlus_grp_consumables">
+		<text>Consumables</text>
 	</string>
-	<string id="ui_mcm_SortingPlus_060medical">
-		<text>Medical</text>
+	<string id="ui_mcm_SortingPlus_grp_quest">
+		<text>Quest</text>
 	</string>
-	<string id="ui_mcm_SortingPlus_070foods">
-		<text>Foods</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_080mutantfoods">
-		<text>Mutant Food</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_090quest">
-		<text>Quest Items</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_100notes">
-		<text>Notes</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_110ammo">
+	<string id="ui_mcm_SortingPlus_grp_ammo">
 		<text>Ammo</text>
 	</string>
-	<string id="ui_mcm_SortingPlus_120mutantparts">
-		<text>Mutant Parts</text>
+	<string id="ui_mcm_SortingPlus_grp_mutant">
+		<text>Mutant Loot</text>
 	</string>
-	<string id="ui_mcm_SortingPlus_130misc">
-		<text>Misc</text>
+	<string id="ui_mcm_SortingPlus_grp_misc">
+		<text>Miscellaneous</text>
 	</string>
-	<string id="ui_mcm_SortingPlus_140upgrades">
+	<string id="ui_mcm_SortingPlus_grp_upgrades">
 		<text>Upgrades</text>
 	</string>
-	<string id="ui_mcm_SortingPlus_150parts">
+	<string id="ui_mcm_SortingPlus_grp_parts">
 		<text>Parts</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_grp_junk">
+		<text>Junk</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_grp_discovered">
+		<text>Discovered</text>
+	</string>
+
+	<!-- Per-kind sort order labels -->
+
+	<!-- Special -->
+	<string id="ui_mcm_SortingPlus_ko_favorites">
+		<text>Favorites</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_favorites_desc">
+		<text>Items marked as favorites via keybind or right-click.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_loadout">
+		<text>ARM - Loadout</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_loadout_desc">
+		<text>Magazines currently loaded in weapons (requires ARM).</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_mags">
+		<text>ARM - Magazines</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_mags_desc">
+		<text>Spare detachable magazines (requires ARM).</text>
+	</string>
+
+	<!-- Weapons -->
+	<string id="ui_mcm_SortingPlus_ko_w_sniper">
+		<text>Weapons - Sniper Rifles</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_sniper_desc">
+		<text>Bolt-action and semi-auto sniper rifles (SVD, Mosin, etc.).</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_rifle">
+		<text>Weapons - Rifles</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_rifle_desc">
+		<text>Assault rifles and battle rifles (AK, M4, FAL, etc.).</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_smg">
+		<text>Weapons - SMGs</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_smg_desc">
+		<text>Submachine guns and PDWs (MP5, Vityaz, P90, etc.).</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_shotgun">
+		<text>Weapons - Shotguns</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_shotgun_desc">
+		<text>Pump-action, semi-auto, and break-action shotguns.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_pistol">
+		<text>Weapons - Pistols</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_pistol_desc">
+		<text>Handguns and revolvers (PM, Glock, Desert Eagle, etc.).</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_melee">
+		<text>Weapons - Melee</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_melee_desc">
+		<text>Knives, axes, and other melee weapons.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_misc">
+		<text>Weapons - Miscellaneous</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_misc_desc">
+		<text>Weapon attachments: scopes, sights, silencers, and other muzzle devices.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_base">
+		<text>Weapons - Base</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_base_desc">
+		<text>Grenade launchers, mounted weapons, and base weapon objects.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_explosive">
+		<text>Weapons - Explosives</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_explosive_desc">
+		<text>Hand grenades, mines, and other throwable explosives.</text>
+	</string>
+
+	<!-- Outfits -->
+	<string id="ui_mcm_SortingPlus_ko_o_armor">
+		<text>Outfits - Armor</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_o_armor_desc">
+		<text>Fallback for armor items not classified into a specific weight class.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_o_heavy">
+		<text>Outfits - Heavy</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_o_heavy_desc">
+		<text>Exoskeletons and heavy combat suits (Nosorog, SEVA-M, etc.).</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_o_medium">
+		<text>Outfits - Medium</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_o_medium_desc">
+		<text>Mid-tier armored suits (Berill, CS-3a, Guardian, etc.).</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_o_sci">
+		<text>Outfits - Scientific</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_o_sci_desc">
+		<text>Scientific and anomaly-resistant suits (SEVA, SSP-99, Ecologist suits, etc.).</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_o_light">
+		<text>Outfits - Light</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_o_light_desc">
+		<text>Leather jackets, trenchcoats, and light stalker suits.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_o_helmet">
+		<text>Outfits - Helmets</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_o_helmet_desc">
+		<text>Helmets, gas masks, and headgear.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_backpack">
+		<text>Outfits - Backpacks</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_backpack_desc">
+		<text>Backpacks that increase carry weight.</text>
+	</string>
+
+	<!-- Belt / Artifacts -->
+	<string id="ui_mcm_SortingPlus_ko_i_attach">
+		<text>Belt - General</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_attach_desc">
+		<text>Belt-slot attachments like containers and pouches.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_arty">
+		<text>Artifacts - Active</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_arty_desc">
+		<text>Artifacts with active properties that can be equipped on belt.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_arty_junk">
+		<text>Artifacts - Junk</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_arty_junk_desc">
+		<text>Low-value artifacts with negligible properties, mainly for selling.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_arty_cont">
+		<text>Artifacts - Containers</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_arty_cont_desc">
+		<text>Lead-lined containers for safe artifact storage and transport.</text>
+	</string>
+
+	<!-- Equipment -->
+	<string id="ui_mcm_SortingPlus_ko_i_device">
+		<text>Equipment - Devices</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_device_desc">
+		<text>Electronic devices: detectors, PDAs, headlamps, binoculars, etc.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_tool">
+		<text>Equipment - Tools</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_tool_desc">
+		<text>Multitools, knives, matches, bolts, and other field tools.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_repair">
+		<text>Equipment - Repair Kits</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_repair_desc">
+		<text>Weapon and armor repair kits, cleaning kits, sewing kits, glue, etc.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_kit">
+		<text>Equipment - Kits</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_kit_desc">
+		<text>Technician toolkits, crafting kits (gunsmithing, drug-making), cooking gear, tents, and sleeping bags.</text>
+	</string>
+
+	<!-- Consumables -->
+	<string id="ui_mcm_SortingPlus_ko_i_medical">
+		<text>Consumables - Medical</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_medical_desc">
+		<text>Medkits, bandages, stimpacks, drugs, and anti-radiation medicine.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_food">
+		<text>Consumables - Food</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_food_desc">
+		<text>Canned goods, bread, MREs, chocolate, and other solid food.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_drink">
+		<text>Consumables - Drinks</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_drink_desc">
+		<text>Water, tea, coffee, energy drinks, vodka, and beer.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_mutant_cooked">
+		<text>Consumables - Cooked Mutant</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_mutant_cooked_desc">
+		<text>Prepared mutant meat: zone-cooked, stewed, or purified.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_tobacco">
+		<text>Consumables - Tobacco</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_tobacco_desc">
+		<text>Cigarettes, cigars, and loose tobacco products.</text>
+	</string>
+
+	<!-- Quest -->
+	<string id="ui_mcm_SortingPlus_ko_i_letter">
+		<text>Quest - Notes</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_letter_desc">
+		<text>Letters, documents, and readable notes.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_quest">
+		<text>Quest - Items</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_quest_desc">
+		<text>Quest-related items, including technician toolkits (Basic/Advanced/Expert).</text>
+	</string>
+
+	<!-- Ammo -->
+	<string id="ui_mcm_SortingPlus_ko_w_ammo">
+		<text>Ammo - Ammunition</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_ammo_desc">
+		<text>All firearm ammunition: pistol, rifle, shotgun rounds, etc.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_ammo_parts">
+		<text>Ammo - Components</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_w_ammo_parts_desc">
+		<text>Ammo crafting components: bullets, casings, and gunpowder.</text>
+	</string>
+
+	<!-- Mutant Loot -->
+	<string id="ui_mcm_SortingPlus_ko_i_mutant_belt">
+		<text>Mutant Loot - Belt Items</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_mutant_belt_desc">
+		<text>Mutant parts equippable on belt (tails, claws, etc.).</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_mutant_part">
+		<text>Mutant Loot - Parts</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_mutant_part_desc">
+		<text>Mutant body parts for trading or crafting (eyes, jaws, pelts, etc.).</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_mutant_raw">
+		<text>Mutant Loot - Raw Meat</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_mutant_raw_desc">
+		<text>Uncooked mutant meat, needs cooking before consumption.</text>
+	</string>
+
+	<!-- Miscellaneous -->
+	<string id="ui_mcm_SortingPlus_ko_i_misc">
+		<text>Miscellaneous - Items</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_misc_desc">
+		<text>Gun oil, broken electronics, rope, scrap clothing, and other salvageable odds and ends.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_faction_patch">
+		<text>Miscellaneous - Faction Patches</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_faction_patch_desc">
+		<text>Collectible faction insignia patches.</text>
+	</string>
+
+	<!-- Upgrades -->
+	<string id="ui_mcm_SortingPlus_ko_i_upgrade">
+		<text>Upgrades</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_upgrade_desc">
+		<text>Weapon and armor upgrade kits installed by technicians.</text>
+	</string>
+
+	<!-- Parts -->
+	<string id="ui_mcm_SortingPlus_ko_i_part_w">
+		<text>Parts - Weapon</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_part_w_desc">
+		<text>Weapon-specific spare parts: barrels, receivers, springs, etc.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_part_o">
+		<text>Parts - Armor</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_part_o_desc">
+		<text>Armor-specific spare parts: plates, padding, servos, etc.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_part">
+		<text>Parts - General</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_i_part_desc">
+		<text>General-purpose parts: capacitors, resistors, copper wire, fasteners, scrap metal, etc.</text>
+	</string>
+
+	<!-- Junk -->
+	<string id="ui_mcm_SortingPlus_ko_junk">
+		<text>Junk</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_ko_junk_desc">
+		<text>Items marked as junk via keybind or right-click.</text>
 	</string>
 
 </string_table>

--- a/gamedata/configs/text/eng/ui_st_sp_keepcaps.xml
+++ b/gamedata/configs/text/eng/ui_st_sp_keepcaps.xml
@@ -1,0 +1,14 @@
+<string_table>
+
+	<string id="st_sp_keep_limit">
+		<text>Keep Limit</text>
+	</string>
+	<string id="st_sp_keep_all">
+		<text>All</text>
+	</string>
+
+	<string id="st_sp_stock_up">
+		<text>Stock Up</text>
+	</string>
+
+</string_table>

--- a/gamedata/configs/text/rus/ui_st_sortingplus.xml
+++ b/gamedata/configs/text/rus/ui_st_sortingplus.xml
@@ -1,178 +1,238 @@
 <!-- 
-	Anomaly Modconfiguration Menu strings
-	
+	Anomaly Modconfiguration Menu strings	
 -->
-
 <string_table>
 	<string id="st_rax_fav">
-		<text>Отметить как избранное</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="st_rax_unfav">
-		<text>Снять отметку с избранного</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="st_rax_junk">
-		<text>Отметить Джанк</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="st_rax_unjunk">
-		<text>Снять отметку о мусоре</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
-
-
 	<string id="ui_mcm_title_SortingPlus">
-		<text>Сортировка Плюс</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ Sorting Plus</text>
 	</string>
-
 	<string id="ui_mcm_menu_SortingPlus">
-		<text>Сортировка Плюс</text>
+		<text>Sorting Plus</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_playerinv">
-		<text>Инвентарь игрока</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_playerinv_desc">
-		<text>Правая сторона на всех экранах кроме торговли.</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_playertrade">
-		<text>Инвентарь обмена игрока</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_playertrade_desc">
-		<text>Правая сторона инвентаря при торговле.</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_npcinv">
-		<text>Инвентарь NPC</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ NPC</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_npcinv_desc">
-		<text>Слева боковые инвторы на всех экранах, кроме торговли.</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_npctrade">
-		<text>Торговый инвентарь NPC</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_npctrade_desc">
-		<text>Левая сторона инвентаря при торговле.</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_useltx">
-		<text>использовать sortingplus.ltx</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ sortingplus.ltx</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_useltx_desc">
-		<text>Игнорирует настройки ниже в пользу тех, которые находятся в sortingpluse.ltx Ltx предлагает более детальный контроль.</text>
-	</string>
-	
-	<string id="ui_mcm_SortingPlus_iconjunk_desc">
-		<text>Пометьте Мусор значком.</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅ sortingplus.ltx, пїЅпїЅпїЅ пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_iconjunk">
-		<text>Отметить Джанк</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>	  
 	</string>
-	
+	<string id="ui_mcm_SortingPlus_iconjunk_desc">
+		<text>пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
+	</string>
+									   
 	<string id="ui_mcm_SortingPlus_hilitejunk">
-		<text>Выделить «нежелательные»</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_hilitejunk_desc">
-		<text>выделите элементы, помеченные как «нежелательные».</text>
+		<text>пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_sortjunk">
-		<text>Используйте «нежелательные»</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_sortjunk_desc">
-		<text>Сортирует «нежелательные» элементы в свою категорию, по умолчанию последняя.</text>
+		<text>пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_selljunk">
-		<text>"Авто" Продажа «нежелательные»</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_selljunk_desc">
-		<text>«нежелательные» который покупает трейдер, будет помещен в панель продажи. Вам все равно нужно нажать кнопку продажи, чтобы завершить.</text>
+		<text>пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ. пїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_iconfavs">
-		<text>Отметить избранное</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_iconfavs_desc">
-		<text>Отметьте избранное значком.</text>
+		<text>пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
-
-
 	<string id="ui_mcm_SortingPlus_hilitefavs">
-		<text>Выделите избранное</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_hilitefavs_desc">
-		<text>Выделите элементы, отмеченные как избранные.</text>
+		<text>пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_sortfavs">
-		<text>Использовать категорию избранного</text>
+		<text>пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_sortfavs_desc">
-		<text>Сортируйте избранное по собственной категории, сначала по умолчанию.</text>
+		<text>пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_putallfavs">
-		<text>Блок «Поместить все» в избранное</text>
+		<text>пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ "пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ"  </text>
 	</string>
 	<string id="ui_mcm_SortingPlus_putallfavs_desc">
-		<text>Избранное не будет перемещено из вашего инвентаря, когда вы все перенесете.</text>
+		<text>пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ "пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ"</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_resort">
-		<text>Пересортировать при маркировке.</text>
+		<text>пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 	<string id="ui_mcm_SortingPlus_resort_desc">
-		<text>Инвентарь будет немедленно применен при пометке избранного / нежелательной почты. В противном случае ожидает следующего открытия инвентаря. Полезный отзыв, если подсветка отключена.</text>
-	</string>
-	
-	
-	
-	
-	
-	
-	
-	<string id="ui_mcm_SortingPlus_000favorites">
-		<text>Избранное</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_999junk">
-		<text>нежелательные</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_010weapons">
-		<text>Оружие</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_020outfits">
-		<text>Наряды</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_030artifacts">
-		<text>Артефакты</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_040devices">
-		<text>Устройства</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_050tools">
-		<text>Инструменты</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_060medical">
-		<text>Медицинское</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_070foods">
-		<text>Еда</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_080mutantfoods">
-		<text>Мутант Еда</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_090quest">
-		<text>Квестовые предметы</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_100notes">
-		<text>Примечания</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_110ammo">
-		<text>Боеприпасы</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_120mutantparts">
-		<text>Части мутантов</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_130misc">
-		<text>разное</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_140upgrades">
-		<text>Обновления</text>
-	</string>
-	<string id="ui_mcm_SortingPlus_150parts">
-		<text>Запчасти</text>
+		<text>пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅ, пїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ. пїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ. пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ</text>
 	</string>
 
+	<!-- Per-kind sort order labels -->
+	<string id="ui_mcm_SortingPlus_favskindrows">
+		<text>Favorites: Group by Kind</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_favskindrows_desc">
+		<text>ON: favorites keep their kind row separation (weapons row, food row, etc.). OFF: all favorites share a single row, sorted by priority.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_usefunctors">
+		<text>Use Right-Click Functors</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_usefunctors_desc">
+		<text>Enable right-click menu entries for marking Favorites/Junk.</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_subkindprio">
+		<text>Within-Row Priority</text>
+	</string>
+	<string id="ui_mcm_SortingPlus_subkindprio_desc">
+		<text>Each category below has a sort number. The whole number sets the row group вЂ” categories with the same whole number share an inventory row (e.g. all weapons at 1). The decimal sets position within that row (e.g. 2.1 before 2.2). When this is OFF, decimals are ignored and all categories with the same whole number sort purely by item size.</text>
+	</string>
 
+	<!-- Group header titles -->
+	<string id="ui_mcm_SortingPlus_grp_special"><text>Special</text></string>
+	<string id="ui_mcm_SortingPlus_grp_weapons"><text>Weapons</text></string>
+	<string id="ui_mcm_SortingPlus_grp_outfits"><text>Outfits</text></string>
+	<string id="ui_mcm_SortingPlus_grp_belt"><text>Belt</text></string>
+	<string id="ui_mcm_SortingPlus_grp_equipment"><text>Equipment</text></string>
+	<string id="ui_mcm_SortingPlus_grp_consumables"><text>Consumables</text></string>
+	<string id="ui_mcm_SortingPlus_grp_quest"><text>Quest</text></string>
+	<string id="ui_mcm_SortingPlus_grp_ammo"><text>Ammo</text></string>
+	<string id="ui_mcm_SortingPlus_grp_mutant"><text>Mutant Loot</text></string>
+	<string id="ui_mcm_SortingPlus_grp_misc"><text>Miscellaneous</text></string>
+	<string id="ui_mcm_SortingPlus_grp_upgrades"><text>Upgrades</text></string>
+	<string id="ui_mcm_SortingPlus_grp_parts"><text>Parts</text></string>
+	<string id="ui_mcm_SortingPlus_grp_junk"><text>Junk</text></string>
+	<string id="ui_mcm_SortingPlus_grp_discovered"><text>Discovered</text></string>
 
-
+	<!-- Per-kind sort order labels -->
+	<string id="ui_mcm_SortingPlus_ko_favorites"><text>Favorites</text></string>
+	<string id="ui_mcm_SortingPlus_ko_favorites_desc"><text>Items marked as favorites via keybind or right-click.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_loadout"><text>ARM - Loadout</text></string>
+	<string id="ui_mcm_SortingPlus_ko_loadout_desc"><text>Magazines currently loaded in weapons (requires ARM).</text></string>
+	<string id="ui_mcm_SortingPlus_ko_mags"><text>ARM - Magazines</text></string>
+	<string id="ui_mcm_SortingPlus_ko_mags_desc"><text>Spare detachable magazines (requires ARM).</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_sniper"><text>Weapons - Sniper Rifles</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_sniper_desc"><text>Bolt-action and semi-auto sniper rifles (SVD, Mosin, etc.).</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_rifle"><text>Weapons - Rifles</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_rifle_desc"><text>Assault rifles and battle rifles (AK, M4, FAL, etc.).</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_smg"><text>Weapons - SMGs</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_smg_desc"><text>Submachine guns and PDWs (MP5, Vityaz, P90, etc.).</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_shotgun"><text>Weapons - Shotguns</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_shotgun_desc"><text>Pump-action, semi-auto, and break-action shotguns.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_pistol"><text>Weapons - Pistols</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_pistol_desc"><text>Handguns and revolvers (PM, Glock, Desert Eagle, etc.).</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_melee"><text>Weapons - Melee</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_melee_desc"><text>Knives, axes, and other melee weapons.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_misc"><text>Weapons - Miscellaneous</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_misc_desc"><text>Weapon attachments: scopes, sights, silencers, and other muzzle devices.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_base"><text>Weapons - Base</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_base_desc"><text>Grenade launchers, mounted weapons, and base weapon objects.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_explosive"><text>Weapons - Explosives</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_explosive_desc"><text>Hand grenades, mines, and other throwable explosives.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_o_armor"><text>Outfits - Armor</text></string>
+	<string id="ui_mcm_SortingPlus_ko_o_armor_desc"><text>Fallback for armor items not classified into a specific weight class.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_o_heavy"><text>Outfits - Heavy</text></string>
+	<string id="ui_mcm_SortingPlus_ko_o_heavy_desc"><text>Exoskeletons and heavy combat suits (Nosorog, SEVA-M, etc.).</text></string>
+	<string id="ui_mcm_SortingPlus_ko_o_sci"><text>Outfits - Scientific</text></string>
+	<string id="ui_mcm_SortingPlus_ko_o_sci_desc"><text>Scientific and anomaly-resistant suits (SEVA, SSP-99, Ecologist suits, etc.).</text></string>
+	<string id="ui_mcm_SortingPlus_ko_o_medium"><text>Outfits - Medium</text></string>
+	<string id="ui_mcm_SortingPlus_ko_o_medium_desc"><text>Mid-tier armored suits (Berill, CS-3a, Guardian, etc.).</text></string>
+	<string id="ui_mcm_SortingPlus_ko_o_light"><text>Outfits - Light</text></string>
+	<string id="ui_mcm_SortingPlus_ko_o_light_desc"><text>Leather jackets, trenchcoats, and light stalker suits.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_o_helmet"><text>Outfits - Helmets</text></string>
+	<string id="ui_mcm_SortingPlus_ko_o_helmet_desc"><text>Helmets, gas masks, and headgear.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_backpack"><text>Outfits - Backpacks</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_backpack_desc"><text>Backpacks that increase carry weight.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_attach"><text>Belt - General</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_attach_desc"><text>Belt-slot attachments like containers and pouches.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_arty"><text>Artifacts - Active</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_arty_desc"><text>Artifacts with active properties that can be equipped on belt.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_arty_junk"><text>Artifacts - Junk</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_arty_junk_desc"><text>Low-value artifacts with negligible properties, mainly for selling.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_arty_cont"><text>Artifacts - Containers</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_arty_cont_desc"><text>Lead-lined containers for safe artifact storage and transport.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_device"><text>Equipment - Devices</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_device_desc"><text>Electronic devices: detectors, PDAs, headlamps, binoculars, etc.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_tool"><text>Equipment - Tools</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_tool_desc"><text>Multitools, knives, matches, bolts, and other field tools.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_repair"><text>Equipment - Repair Kits</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_repair_desc"><text>Weapon and armor repair kits, cleaning kits, sewing kits, glue, etc.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_kit"><text>Equipment - Kits</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_kit_desc"><text>Technician toolkits, crafting kits (gunsmithing, drug-making), cooking gear, tents, and sleeping bags.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_medical"><text>Consumables - Medical</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_medical_desc"><text>Medkits, bandages, stimpacks, drugs, and anti-radiation medicine.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_food"><text>Consumables - Food</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_food_desc"><text>Canned goods, bread, MREs, chocolate, and other solid food.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_drink"><text>Consumables - Drinks</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_drink_desc"><text>Water, tea, coffee, energy drinks, vodka, and beer.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_mutant_cooked"><text>Consumables - Cooked Mutant</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_mutant_cooked_desc"><text>Prepared mutant meat: zone-cooked, stewed, or purified.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_tobacco"><text>Consumables - Tobacco</text></string>
+	<string id="ui_mcm_SortingPlus_ko_tobacco_desc"><text>Cigarettes, cigars, and loose tobacco products.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_letter"><text>Quest - Notes</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_letter_desc"><text>Letters, documents, and readable notes.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_quest"><text>Quest - Items</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_quest_desc"><text>Quest-related items, including technician toolkits (Basic/Advanced/Expert).</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_ammo"><text>Ammo - Ammunition</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_ammo_desc"><text>All firearm ammunition: pistol, rifle, shotgun rounds, etc.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_ammo_parts"><text>Ammo - Components</text></string>
+	<string id="ui_mcm_SortingPlus_ko_w_ammo_parts_desc"><text>Ammo crafting components: bullets, casings, and gunpowder.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_mutant_belt"><text>Mutant Loot - Belt Items</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_mutant_belt_desc"><text>Mutant parts equippable on belt (tails, claws, etc.).</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_mutant_part"><text>Mutant Loot - Parts</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_mutant_part_desc"><text>Mutant body parts for trading or crafting (eyes, jaws, pelts, etc.).</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_mutant_raw"><text>Mutant Loot - Raw Meat</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_mutant_raw_desc"><text>Uncooked mutant meat, needs cooking before consumption.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_misc"><text>Miscellaneous - Items</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_misc_desc"><text>Gun oil, broken electronics, rope, scrap clothing, and other salvageable odds and ends.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_faction_patch"><text>Miscellaneous - Faction Patches</text></string>
+	<string id="ui_mcm_SortingPlus_ko_faction_patch_desc"><text>Collectible faction insignia patches.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_upgrade"><text>Upgrades</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_upgrade_desc"><text>Weapon and armor upgrade kits installed by technicians.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_part_w"><text>Parts - Weapon</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_part_w_desc"><text>Weapon-specific spare parts: barrels, receivers, springs, etc.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_part_o"><text>Parts - Armor</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_part_o_desc"><text>Armor-specific spare parts: plates, padding, servos, etc.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_part"><text>Parts - General</text></string>
+	<string id="ui_mcm_SortingPlus_ko_i_part_desc"><text>General-purpose parts: capacitors, resistors, copper wire, fasteners, scrap metal, etc.</text></string>
+	<string id="ui_mcm_SortingPlus_ko_junk"><text>Junk</text></string>
+	<string id="ui_mcm_SortingPlus_ko_junk_desc"><text>Items marked as junk via keybind or right-click.</text></string>
 </string_table>

--- a/gamedata/configs/text/rus/ui_st_sp_keepcaps.xml
+++ b/gamedata/configs/text/rus/ui_st_sp_keepcaps.xml
@@ -1,0 +1,14 @@
+<string_table>
+
+	<string id="st_sp_keep_limit">
+		<text>Keep Limit</text>
+	</string>
+	<string id="st_sp_keep_all">
+		<text>All</text>
+	</string>
+
+	<string id="st_sp_stock_up">
+		<text>Stock Up</text>
+	</string>
+
+</string_table>

--- a/gamedata/configs/ui/ui_sp_keepcaps.xml
+++ b/gamedata/configs/ui/ui_sp_keepcaps.xml
@@ -1,0 +1,41 @@
+<w>
+	<dialog x="362" y="319" width="300" height="130" stretch="1">
+		<background x="0" y="0" width="300" height="130" stretch="1">
+			<texture>ui_inGame2_message_box</texture>
+		</background>
+
+		<title x="0" y="10" width="300" height="22">
+			<text font="graffiti19" r="220" g="220" b="220" align="c" vert_align="c">st_sp_keep_limit</text>
+		</title>
+
+		<input x="50" y="42" width="200" height="30" max_symb_count="5">
+			<text x="5" font="letterica18" vert_align="c" align="l"/>
+			<texture>ui_inGame2_edit_box_2</texture>
+		</input>
+
+		<btn_ok x="20" y="88" width="70" height="28" stretch="1">
+			<text font="letterica16">ui_inv_ok</text>
+			<texture>ui_button_ordinary</texture>
+		</btn_ok>
+
+		<btn_all x="115" y="88" width="70" height="28" stretch="1">
+			<text font="letterica16">st_sp_keep_all</text>
+			<texture>ui_button_ordinary</texture>
+		</btn_all>
+
+		<btn_cancel x="210" y="88" width="70" height="28" stretch="1">
+			<text font="letterica16">ui_inv_cancel</text>
+			<texture>ui_button_ordinary</texture>
+		</btn_cancel>
+	</dialog>
+
+	<stockup_button x="0" y="0" width="90" height="24" stretch="1">
+		<text font="graffiti22" align="c" y="3">st_sp_stock_up</text>
+		<text_color>
+			<e color="ui_6"/>
+			<t color="ui_white"/>
+			<d color="ui_5"/>
+			<h color="ui_white"/>
+		</text_color>
+	</stockup_button>
+</w>

--- a/gamedata/scripts/zzz_rax_sortingplus_mcm.script
+++ b/gamedata/scripts/zzz_rax_sortingplus_mcm.script
@@ -20,6 +20,7 @@ SORTFAVS = true
 HILITEFAVS = true
 ICONFAVS = true
 BLOCKPUTALLFAVS = true
+FAVSKINDROWS = true
 AUTOSELLJUNK = true
 RESORT = true
 local favorite_itms = {}
@@ -63,15 +64,15 @@ end
 
 function icon_junk(cell, obj, sec)
 	if bags[cell.container.ID] and ICONJUNK and junk_itms[cell.section] then
-		axis = utils_xml.get_item_axis(sec)
+		local axis = utils_xml.get_item_axis(sec)
 		return {texture = "ui\\sortingplus\\icon-junk",y = axis.h / 2 - 7 or 0, x = axis.w - 15, w = 15, h = 15}
 	end
 end
 --{texture = "ui_am_propery_01", x = 1, y = 1, w = 15, h = 15}
 function icon_favs(cell, obj, sec)
 	if bags[cell.container.ID] and ICONFAVS and favorite_itms[cell.section] then
-		axis = utils_xml.get_item_axis(sec)
-		return {texture = "ui\\sortingplus\\icon-favourite", y = axis.h / 2 - 7 or 0, x = axis.w - 15, w = 15, h = 15}
+		local axis = utils_xml.get_item_axis(sec)
+		return {texture = "ui\\sortingplus\\icon-favourite", y = axis.h / 2 - 11 or 0, x = 0 , w = 15, h = 15}
 	end
 end
 
@@ -118,105 +119,211 @@ function actor_on_first_update()
     ui_inventory.GUI.CC["npc_trade_bag"].sort_method = NPCTRADE and "kind" or "sizekind"
 end
 
-local ui_catagories = {}
 local item_order = {}
 local kind_overrides = {}
+local item_sort_prio = {}
+-- Table mapping kind → MCM option id (e.g. "w_rifle" → "ko_w_rifle")
+local kind_mcm_map = {}
+-- Table of kind defaults read from LTX (kind → default float)
+local kind_defaults = {}
+-- Combined MCM kinds that expand to multiple real kinds
+local kind_aliases = {
+    o_armor = {"o_heavy", "o_sci", "o_medium", "o_light", "i_backpack"},
+}
 local ab_w, ab_h, ab_k = {}, {}, {}
 local a_sec, a_w, a_h, a_k = nil, nil, nil, nil
 local b_sec, b_w, b_h, b_k = nil, nil, nil, nil
 
-function loadsettings()
-    -- here we test to make sure ui_mcm exists before trying to call it's get function.
-    if ui_mcm then
-        PLAYERINV = ui_mcm.get("SortingPlus/playerinv")
-        PLAYERTRADE = ui_mcm.get("SortingPlus/playertrade")
-        NPCINV = ui_mcm.get("SortingPlus/npcinv")
-        NPCTRADE = ui_mcm.get("SortingPlus/npctrade")
-        SORTJUNK = ui_mcm.get("SortingPlus/sortjunk")
-        HILITEJUNK = ui_mcm.get("SortingPlus/hilitejunk")
-        ICONJUNK = ui_mcm.get("SortingPlus/iconjunk")
-        AUTOSELLJUNK = ui_mcm.get("SortingPlus/selljunk")
-        SORTFAVS = ui_mcm.get("SortingPlus/sortfavs")
-        HILITEFAVS = ui_mcm.get("SortingPlus/hilitefavs")
-        ICONFAVS = ui_mcm.get("SortingPlus/iconfavs")
-        BLOCKPUTALLFAVS = ui_mcm.get("SortingPlus/putallfavs")
-        RESORT = ui_mcm.get("SortingPlus/resort")
-        USEFUNCTORS = ui_mcm.get("SortingPlus/usefunctors")
-        item_order = {} --clear the cached item order since user may have changed those
-        ab_k = {} -- (dis/en)able junk/favs sorting requires this to be cleared.
+-- Populates kind_overrides from LTX [kind_overrides] + prefix-based i_part split.
+-- Runs in both MCM and LTX modes.
+local function apply_section_overrides()
+    -- Read explicit overrides from LTX
+    local n = ini:line_count("kind_overrides")
+    for i = 0, n - 1 do
+        local result, sec, kind = ini:r_line_ex("kind_overrides", i, "", "")
+        if sec and kind then
+            kind_overrides[sec] = kind
+        end
+    end
 
-        -- use the function to read the lxt if set to
-        if ui_mcm.get("SortingPlus/useltx") == true then
-            set_item_order()
-        else
-            --other wise loop thru ui_catagories, built when MCM menu is next function, and use the number entered into the mcm menu as the sorting order. 
-            for key, value in pairs(ui_catagories) do
-                for i = 2, #value do
-                    item_order[value[i]] = ui_mcm.get("SortingPlus/" .. key)
+    -- Split i_part into sub-kinds by section prefix:
+    -- prt_w_ → i_part_w (weapon parts), prt_o_ → i_part_o (armor parts)
+    ini_sys:section_for_each(function(sec)
+        if kind_overrides[sec] then return end
+        local kind = ini_sys:r_string_ex(sec, "kind")
+        if kind ~= "i_part" then return end
+        if string.sub(sec, 1, 5) == "prt_w" then
+            kind_overrides[sec] = "i_part_w"
+        elseif string.sub(sec, 1, 5) == "prt_o" then
+            kind_overrides[sec] = "i_part_o"
+        end
+    end)
+end
+
+local function load_mcm_settings()
+    PLAYERINV = ui_mcm.get("SortingPlus/playerinv")
+    PLAYERTRADE = ui_mcm.get("SortingPlus/playertrade")
+    NPCINV = ui_mcm.get("SortingPlus/npcinv")
+    NPCTRADE = ui_mcm.get("SortingPlus/npctrade")
+    SORTJUNK = ui_mcm.get("SortingPlus/sortjunk")
+    HILITEJUNK = ui_mcm.get("SortingPlus/hilitejunk")
+    ICONJUNK = ui_mcm.get("SortingPlus/iconjunk")
+    AUTOSELLJUNK = ui_mcm.get("SortingPlus/selljunk")
+    SORTFAVS = ui_mcm.get("SortingPlus/sortfavs")
+    HILITEFAVS = ui_mcm.get("SortingPlus/hilitefavs")
+    ICONFAVS = ui_mcm.get("SortingPlus/iconfavs")
+    BLOCKPUTALLFAVS = ui_mcm.get("SortingPlus/putallfavs")
+    FAVSKINDROWS = ui_mcm.get("SortingPlus/favskindrows")
+    RESORT = ui_mcm.get("SortingPlus/resort")
+    USEFUNCTORS = ui_mcm.get("SortingPlus/usefunctors")
+    SUBKINDPRIO = ui_mcm.get("SortingPlus/subkindprio")
+
+    if ui_mcm.get("SortingPlus/useltx") == true then
+        set_item_order()
+    else
+        for kind, mcm_id in pairs(kind_mcm_map) do
+            item_order[kind] = ui_mcm.get("SortingPlus/" .. mcm_id)
+        end
+        for alias, real_kinds in pairs(kind_aliases) do
+            if item_order[alias] then
+                for _, rk in ipairs(real_kinds) do
+                    item_order[rk] = item_order[alias]
                 end
             end
-
-            item_order["na"] = size_table(item_order) + 1 --fail case
         end
-    else
-        set_item_order() --without mcm read from the lxt
+        item_order["na"] = 9999
     end
-	if HILITEFAVS then rax_persistent_highlight.register("aafavorite_itms", check_favs) end
-    if HILITEJUNK then rax_persistent_highlight.register("aajunk_itms", check_junk) end
-	if USEFUNCTORS then
-		rax_dynamic_custom_functor.add_functor("SP_fav", fav_menu_string, menu_precond, fav_menu_action)
-		rax_dynamic_custom_functor.add_functor("SP_junk", junk_menu_string, menu_precond, junk_menu_action)
-	end
-	if ICONJUNK then rax_icon_layers.register("aajunk_itms", icon_junk) end
-	if ICONFAVS then rax_icon_layers.register("abfavorite_itms", icon_favs) end
-	
+    if not SUBKINDPRIO then
+        for k, v in pairs(item_order) do
+            item_order[k] = math.floor(v)
+        end
+    end
+end
 
+function loadsettings()
+    -- Clear caches
+    item_order = {}
+    ab_k = {}
+    item_sort_prio = {}
+    kind_overrides = {}
+    apply_section_overrides()
+
+    -- Load settings from MCM or LTX fallback
+    if ui_mcm then
+        load_mcm_settings()
+    else
+        set_item_order()
+    end
+
+    -- Load within-kind priority from LTX
+    local n = ini:line_count("item_sort_priority") or 0
+    for i = 0, n - 1 do
+        local result, sec, prio = ini:r_line_ex("item_sort_priority", i, "", "")
+        if sec and prio then
+            item_sort_prio[sec] = tonumber(prio) or 1000
+        end
+    end
+
+    -- Re-register visual callbacks
+    if HILITEFAVS then rax_persistent_highlight.register("aafavorite_itms", check_favs) end
+    if HILITEJUNK then rax_persistent_highlight.register("aajunk_itms", check_junk) end
+    if USEFUNCTORS then
+        rax_dynamic_custom_functor.add_functor("SP_fav", fav_menu_string, menu_precond, fav_menu_action)
+        rax_dynamic_custom_functor.add_functor("SP_junk", junk_menu_string, menu_precond, junk_menu_action)
+    end
+    if ICONJUNK then rax_icon_layers.register("aajunk_itms", icon_junk) end
+    if ICONFAVS then rax_icon_layers.register("abfavorite_itms", icon_favs) end
 end
 
 
+
 function on_mcm_load() --builds mcm menu
-		t = {
-				{ id= "sorting"				 ,type= "slide"	  ,link= "ui_options_slider_economy_diff"	 ,text= "ui_mcm_title_SortingPlus"		,size= {512,50}		,spacing= 20 },
-				{id = "playerinv", type = "check", val = 1, def = true},
-				{id = "playertrade", type = "check", val = 1, def = true},
-				{id = "npcinv", type = "check", val = 1, def = true},
-				{id = "npctrade", type = "check", val = 1, def = true},
-				{id = "line", type = "line"},
-				{id = "hilitejunk", type = "check", val = 1, def = true},
-				{id = "iconjunk", type = "check", val = 1, def = true},
-				{id = "sortjunk", type = "check", val = 1, def = true},
-				{id = "selljunk", type = "check", val = 1, def = true},				
-				{id = "hilitefavs", type = "check", val = 1, def = true},
-				{id = "iconfavs", type = "check", val = 1, def = true},
-				{id = "sortfavs", type = "check", val = 1, def = true},
-				{id = "putallfavs", type = "check", val = 1, def = true},
-				{id = "resort", type = "check", val = 1, def = false},
-				{id = "usefunctors", type = "check", val = 1, def = true},
-				
-				{id = "line", type = "line"},
-				{id = "useltx", type = "check", val = 1, def = false},
-			}
-	
-	local n = ini:line_count("sortingplusmcm") --the catagories portion is dynamic
-	for i=0,n-1 do
-		local result, catgory, kinds = ini:r_line_ex("sortingplusmcm",i,"","") --catagory is a text entry field in the mcm menu, kinds is the list of kinds grouped in that catagory
-		if magazine_binder or not ( catgory == "002mags" or catgory == "001loadout") then
-			if catgory and kinds then
-				ui_catagories[catgory] = str_explode(kinds,",") -- building ui_catagories list
-				if  tonumber(ui_catagories[catgory][1]) then --first element in list of kinds is the defualt value for the catagory 
-					table.insert(t, {id=catgory,  type = "input", val = 2, def = tonumber(ui_catagories[catgory][1]), min = -100, max = 1000}) -- here we push the entry into the menu table
-				else
-					ui_catagories[catgory] = nil -- if it doesn't start with a number it is invalid get rid of it.
+	local t = {
+		{ id= "sorting"      ,type= "slide" ,link= "ui_options_slider_economy_diff" ,text= "ui_mcm_title_SortingPlus" ,size= {512,50} ,spacing= 20 },
+		{id = "hilitefavs", type = "check", val = 1, def = true},
+		{id = "iconfavs", type = "check", val = 1, def = true},
+		{id = "sortfavs", type = "check", val = 1, def = true},
+		{id = "favskindrows", type = "check", val = 1, def = true},
+		{id = "putallfavs", type = "check", val = 1, def = true},
+		{id = "line", type = "line"},
+		{id = "hilitejunk", type = "check", val = 1, def = true},
+		{id = "iconjunk", type = "check", val = 1, def = true},
+		{id = "sortjunk", type = "check", val = 1, def = true},
+		{id = "selljunk", type = "check", val = 1, def = true},
+		{id = "line", type = "line"},
+		{id = "playerinv", type = "check", val = 1, def = true},
+		{id = "playertrade", type = "check", val = 1, def = true},
+		{id = "npcinv", type = "check", val = 1, def = true},
+		{id = "npctrade", type = "check", val = 1, def = true},
+		{id = "resort", type = "check", val = 1, def = false},
+		{id = "usefunctors", type = "check", val = 1, def = true},
+		{id = "line", type = "line"},
+		{id = "useltx", type = "check", val = 1, def = false},
+		{id = "subkindprio", type = "check", val = 1, def = true},
+		{id = "line", type = "line"},
+	}
+
+	-- 1. Read kind defaults from LTX
+	kind_defaults = {}
+	kind_mcm_map = {}
+	local n = ini:line_count("sortingplus_kind_defaults")
+	for i = 0, n - 1 do
+		local result, kind, val = ini:r_line_ex("sortingplus_kind_defaults", i, "", "")
+		if kind and val then
+			kind_defaults[kind] = tonumber(val) or 30
+		end
+	end
+
+	-- 2. Read display groups from LTX (ordered)
+	local groups = {}        -- ordered list of {id, kinds}
+	local grouped_kinds = {} -- set of kinds already in a group
+	local ng = ini:line_count("sortingplus_kind_groups")
+	for i = 0, ng - 1 do
+		local result, grp_id, kinds_str = ini:r_line_ex("sortingplus_kind_groups", i, "", "")
+		if grp_id and kinds_str then
+			local kinds_list = str_explode(kinds_str, ",")
+			-- Filter out ARM kinds if magazine_binder not present
+			local filtered = {}
+			for _, k in ipairs(kinds_list) do
+				if magazine_binder or (k ~= "loadout" and k ~= "mags") then
+					table.insert(filtered, k)
+					grouped_kinds[k] = true
 				end
+			end
+			if #filtered > 0 then
+				table.insert(groups, {id = grp_id, kinds = filtered})
 			end
 		end
 	end
 
-			
-		
-	op = { id= "SortingPlus"      	 	,sh=true ,gr= t	} -- put the list of setting into the table describing the entire MCM menu
-			
-		return op
+	-- 3. Scan ini_sys for any kinds not in defaults → add to "Discovered" group
+	local discovered = {}
+	ini_sys:section_for_each(function(sec)
+		local kind = ini_sys:r_string_ex(sec, "kind")
+		if kind and not kind_defaults[kind] and not grouped_kinds[kind] then
+			kind_defaults[kind] = 30
+			grouped_kinds[kind] = true
+			table.insert(discovered, kind)
+		end
+	end)
+	if #discovered > 0 then
+		table.sort(discovered)
+		table.insert(groups, {id = "grp_discovered", kinds = discovered})
+	end
+
+	-- 4. Generate MCM widgets: title per group, input per kind
+	-- Labels resolved by MCM via "ui_mcm_SortingPlus_<id>" string lookup
+	for _, grp in ipairs(groups) do
+		table.insert(t, {id = grp.id, type = "title", text = "ui_mcm_SortingPlus_" .. grp.id})
+		for _, kind in ipairs(grp.kinds) do
+			local mcm_id = "ko_" .. kind
+			kind_mcm_map[kind] = mcm_id
+			table.insert(t, {id = mcm_id, type = "input", val = 2, def = kind_defaults[kind] or 30, min = -100, max = 1000})
+		end
+	end
+
+	local op = { id= "SortingPlus", sh=true, gr= t }
+	return op
 end
 
 
@@ -233,16 +340,7 @@ function set_item_order()
     end
 
     item_order["na"] = size_table(item_order) + 1
-    n = ini:line_count("kind_overrides")
-
-    for i = 0, n - 1 do
-        local result, sec, kind = ini:r_line_ex("kind_overrides", i, "", "")
-
-        if sec and kind then
-            kind_overrides[sec] = kind
-            --printf("override %s as %s", sec, kind)
-        end
-    end
+    -- kind_overrides and item_sort_prio are now loaded by loadsettings()
 end
 
 function get_sort_kind(sec)
@@ -252,50 +350,29 @@ end
 
 
 
-function sort_info(asec, bsec)
-    ---	printf("Print table")
-    ---store_table(item_order)
-    -- A
-    a_sec = asec
-	axis = utils_xml.get_item_axis(a_sec,1)
-    if (not ab_w[a_sec]) then
-        ab_w[a_sec] = axis.w
+local function ensure_cached(sec)
+    if not ab_w[sec] then
+        local axis = utils_xml.get_item_axis(sec, 1)
+        ab_w[sec] = axis.w
+        ab_h[sec] = axis.h
     end
-
-    if (not ab_h[a_sec]) then
-        ab_h[a_sec] = axis.h
-    end
-
-    if (not ab_k[a_sec]) then
-        ab_k[a_sec] = get_sort_kind(a_sec)
-
-        if (not item_order[ab_k[a_sec]]) then
-            ab_k[a_sec] = "na"
+    if not ab_k[sec] then
+        ab_k[sec] = get_sort_kind(sec)
+        if not item_order[ab_k[sec]] then
+            ab_k[sec] = "na"
         end
     end
+end
 
+function sort_info(asec, bsec)
+    a_sec = asec
+    ensure_cached(a_sec)
     a_w = ab_w[a_sec]
     a_h = ab_h[a_sec]
     a_k = item_order[ab_k[a_sec]]
-    -- B
+
     b_sec = bsec
-	axis = utils_xml.get_item_axis(b_sec,1)
-    if (not ab_w[b_sec]) then
-        ab_w[b_sec] = axis.w
-    end
-
-    if (not ab_h[b_sec]) then
-        ab_h[b_sec] = axis.h
-    end
-
-    if (not ab_k[b_sec]) then
-        ab_k[b_sec] = get_sort_kind(b_sec)
-
-        if (not item_order[ab_k[b_sec]]) then
-            ab_k[b_sec] = "na"
-        end
-    end
-
+    ensure_cached(b_sec)
     b_w = ab_w[b_sec]
     b_h = ab_h[b_sec]
     b_k = item_order[ab_k[b_sec]]
@@ -306,6 +383,13 @@ function sort_by_size(t, a, b)
         sort_info(t[a], t[b])
     else
         sort_info(t[a]:section(), t[b]:section())
+    end
+
+    -- Within-kind priority check
+    local a_p = item_sort_prio[a_sec] or 1000
+    local b_p = item_sort_prio[b_sec] or 1000
+    if a_p ~= b_p then
+        return a_p < b_p
     end
 
     -- Comparison
@@ -328,34 +412,27 @@ function sort_by_size(t, a, b)
     return a_w > b_w
 end
 
+local function resolve_sort_keys(t, a, b)
+    local is_string = type(t[a]) == "string"
+    local sec_a = is_string and t[a] or t[a]:section()
+    local sec_b = is_string and t[b] or t[b]:section()
+    sort_info(sec_a, sec_b)
+    local a_o = item_order[SORTFAVS and favorite_itms[sec_a] or SORTJUNK and junk_itms[sec_a]] or false
+    local b_o = item_order[SORTFAVS and favorite_itms[sec_b] or SORTJUNK and junk_itms[sec_b]] or false
+    return a_o, b_o, is_string
+end
+
 function sort_by_kind(t, a, b)
-	local a_o,b_o
-	if (type(t[a]) == "string") then
-        sort_info(t[a], t[b])
-		a_o = item_order[SORTFAVS and favorite_itms[t[a]] or SORTJUNK and junk_itms[t[a]]] or false
-		b_o = item_order[SORTFAVS and favorite_itms[t[b]] or SORTJUNK and junk_itms[t[b]]] or false
-    else
-        sort_info(t[a]:section(), t[b]:section())
-		a_o = item_order[SORTFAVS and favorite_itms[t[a]:section()] or SORTJUNK and junk_itms[t[a]:section()]] or false
-		b_o = item_order[SORTFAVS and favorite_itms[t[b]:section()] or SORTJUNK and junk_itms[t[b]:section()]] or false
-		
-        if magazine_binder then
-            if magazine_binder.is_carried_mag(t[a]:id()) then
-                a_k = item_order["loadout"]
-            end
-
-            if magazine_binder.is_carried_mag(t[b]:id()) then
-                b_k = item_order["loadout"]
-            end
-        end
+    local a_o, b_o, is_string = resolve_sort_keys(t, a, b)
+    if not is_string and magazine_binder then
+        if magazine_binder.is_carried_mag(t[a]:id()) then a_k = item_order["loadout"] end
+        if magazine_binder.is_carried_mag(t[b]:id()) then b_k = item_order["loadout"] end
     end
-	if a_o ~= b_o then --if the overrides are equal sort by the actual kind
-		a_k = a_o or a_k --otherwise sort by the overide if it exists or the orginal kind
-		b_k = b_o or b_k
-	end
-	
+    if a_o ~= b_o then
+        a_k = a_o or a_k
+        b_k = b_o or b_k
+    end
     if a_k == b_k then return sort_by_size(t, a, b) end
-
     return a_k < b_k
 end
 
@@ -364,64 +441,36 @@ function sort_by_index(t, a, b)
 end
 
 function sort_by_sizekind(t, a, b)
- 	local a_o,b_o
-	if (type(t[a]) == "string") then
-        sort_info(t[a], t[b])
-		a_o = item_order[SORTFAVS and favorite_itms[t[a]] or SORTJUNK and junk_itms[t[a]]] or false
-		b_o = item_order[SORTFAVS and favorite_itms[t[b]] or SORTJUNK and junk_itms[t[b]]] or false
-    else
-        sort_info(t[a]:section(), t[b]:section())
-		a_o = item_order[SORTFAVS and favorite_itms[t[a]:section()] or SORTJUNK and junk_itms[t[a]:section()]] or false
-		b_o = item_order[SORTFAVS and favorite_itms[t[b]:section()] or SORTJUNK and junk_itms[t[b]:section()]] or false
-		
-        if magazine_binder then
-            if magazine_binder.is_carried_mag(t[a]:id()) then
-                a_o = item_order["loadout"]
-            end
-
-            if magazine_binder.is_carried_mag(t[b]:id()) then
-                b_o = item_order["loadout"]
-            end
-        end
+    local a_o, b_o, is_string = resolve_sort_keys(t, a, b)
+    if not is_string and magazine_binder then
+        if magazine_binder.is_carried_mag(t[a]:id()) then a_o = item_order["loadout"] end
+        if magazine_binder.is_carried_mag(t[b]:id()) then b_o = item_order["loadout"] end
     end
-
-	if a_o ~= b_o then --if the overrides are equal sort by the actual kind
-		a_k = a_o or a_k --otherwise sort by the overide if it exists or the orginal kind
-		b_k = b_o or b_k
-	end
- 
-
-
- -- Comparison
-    --printf("%s - %s", a_sec, b_sec)
-	-- override wins first
-	if not (a_o or b_o) then
-		--\\ bigger width wins
-		if (a_w == b_w) then
-			--\\ bigger height wins
-			if (a_h == b_h) then
-				--\\ important kind wins
-				if a_k == b_k then
-					--\\ alphaptic order wins
-					if (a_sec == b_sec) then
-						--\\ better condition wins
-						if (type(t[a]) == "string") then return false end --true
-
-						return t[a]:condition() > t[b]:condition()
-					end
-
-					return a_sec < b_sec
-				end
-
-				return a_k < b_k
-			end
-
-			return a_h > b_h
-		end
-		
-		return a_w > b_w
-	end
-	return a_k < b_k
+    if a_o ~= b_o then
+        a_k = a_o or a_k
+        b_k = b_o or b_k
+    end
+    -- override wins first
+    if not (a_o or b_o) then
+        if (a_w == b_w) then
+            if (a_h == b_h) then
+                if a_k == b_k then
+                    local a_p = item_sort_prio[a_sec] or 1000
+                    local b_p = item_sort_prio[b_sec] or 1000
+                    if a_p ~= b_p then return a_p < b_p end
+                    if (a_sec == b_sec) then
+                        if is_string then return false end
+                        return t[a]:condition() > t[b]:condition()
+                    end
+                    return a_sec < b_sec
+                end
+                return a_k < b_k
+            end
+            return a_h > b_h
+        end
+        return a_w > b_w
+    end
+    return a_k < b_k
 end
 
 function sort_by_props(t, a, b)
@@ -455,7 +504,7 @@ function utils_ui.UICellContainer.FindFreeCell(self, obj, sec)
         sec = obj and obj:section()
     end
 
-	axis = utils_xml.get_item_axis(sec,1)
+	local axis = utils_xml.get_item_axis(sec,1)
 	local w = axis.w
 	local h = axis.h
     -- Avoid icons that don't fit
@@ -463,8 +512,17 @@ function utils_ui.UICellContainer.FindFreeCell(self, obj, sec)
 
     -- Sorting by kind: when sorting a new kind, always start from last row taken by previous kind
     if self.sort_method == "kind" then
-        local sort_k = magazine_binder and obj and magazine_binder.is_carried_mag(obj:id()) and "loadout" or SORTFAVS and favorite_itms[sec] or SORTJUNK and junk_itms[sec] or  ab_k[sec]
-		self.rKind.current = item_order[sort_k]
+        local sort_k = magazine_binder and obj and magazine_binder.is_carried_mag(obj:id()) and "loadout" or SORTJUNK and junk_itms[sec] or ab_k[sec]
+		local sort_order = item_order[sort_k]
+		if SORTFAVS and favorite_itms[sec] then
+			if FAVSKINDROWS then
+				sort_order = -1000 - (sort_order or 0)
+			else
+				sort_order = -1000
+			end
+		end
+		-- Integer part = row group, decimal part = within-row ordering (handled by sort comparators)
+		self.rKind.current = math.floor(sort_order or 0)
 
         if (self.rKind.last ~= self.rKind.current) then
             self.rKind.last = self.rKind.current
@@ -489,11 +547,11 @@ function utils_ui.UICellContainer.FindFreeCell(self, obj, sec)
 end
 
 utils_ui.UICellContainer.OnKeyboardBase = utils_ui.UICellContainer.OnKeyboard --make a copy of the original version
-tg_wait = 0
+local tg_wait = 0
 
 --editing this is easier than using a normal key callback because this function has "selfself.hover.idx" that is the cell the mouse is over
 function utils_ui.UICellContainer:OnKeyboard(dik, keyboard_action)
-    tg = time_global() --this function gets called repetedly when key pressed, using a timer to lcean that up
+    local tg = time_global() --this function gets called repetedly when key pressed, using a timer to lcean that up
 
     -- for some reason self.hover.idx can be false when the first of the batch of keyboard events comes in. this makes sure the timer isn't triggered until it has a value
     if ((dik == K_K or dik == K_J) and tg > tg_wait and self.hover.idx) then
@@ -520,7 +578,7 @@ function utils_ui.UICellContainer:OnKeyboard(dik, keyboard_action)
     self:OnKeyboardBase(dik, keyboard_action) -- pass key on to orginal version
 end
 
-local PUTALL = false --flag to keep track of put all being in progress
+PUTALL = false --flag to keep track of put all being in progress
 ui_inventory.UIInventory.LMode_PutAllBase = ui_inventory.UIInventory.LMode_PutAll --copy of the base script.
 
 
@@ -568,8 +626,14 @@ function ui_inventory.UIInventory:LMode_PutAll()
 end
 
 -- i wish there was a ActorMenu_on_item_before_move_all callback then the above PUTALL bs wouldn't be needed.
+local _pre_sp_ret = nil -- snapshot of flags.ret_value before SortingPlus modifies it
 function ActorMenu_on_item_before_move(flags, npc_id, obj, mode, bag)
+    _pre_sp_ret = flags.ret_value
     flags.ret_value = flags.ret_value and not (PUTALL and favorite_itms[obj:section()]) -- if PUTALL is true, and the item is in the favorite_itms list set the flag to false, to block the item being transfered.
+end
+
+function get_pre_sp_ret()
+    return _pre_sp_ret
 end
 
 -- moves items to actor trade bag. Action_Move checks for quest itmes, vendor doesn't want ect. 
@@ -612,13 +676,13 @@ end
 
 
 function fav_menu_action(obj)
-    sec = obj:section()
+    local sec = obj:section()
 	set_favorite(sec,not favorite_itms[sec])
 	rax_icon_layers.refresh(RESORT and 1)
 end
 
 function junk_menu_action(obj)
-    sec = obj:section()
+    local sec = obj:section()
 
     -- same things but for junk list
 	set_junk(sec, not junk_itms[sec])
@@ -650,3 +714,25 @@ function set_junk(sec, state)
         junk_itms[sec] = nil
     end
 end
+
+
+local UIIbaseHL = ui_inventory.UIInventory.Highlight
+function ui_inventory.UIInventory:Highlight(sec, bag_id)
+  self.highlight_set = true
+  UIIbaseHL(self, sec, bag_id)
+end
+
+local UIIbaseUHL = ui_inventory.UIInventory.UnHighlight_All
+function ui_inventory.UIInventory:UnHighlight_All()
+  if self.highlight_set then
+    UIIbaseUHL(self)
+    self.highlight_set = false
+  end
+end
+
+local cellupdate = utils_ui.UICellItem.Update
+function utils_ui.UICellItem:Update(obj)
+  self:Highlight()
+  return cellupdate(self, obj)
+end
+

--- a/gamedata/scripts/zzzz_rax_sortingplus_keepcaps.script
+++ b/gamedata/scripts/zzzz_rax_sortingplus_keepcaps.script
@@ -1,0 +1,381 @@
+-- SortingPlus Keep Caps
+-- Per-item favorite keep limits for SortingPlus "Put All"
+-- Favorited items with a keep limit will have excess deposited during Put All.
+-- "Stock Up" button: inverse of Put All — fills favorites from container up to limits.
+
+local favorite_limits = {} -- favorite_limits[section] = number or nil (nil = keep all)
+local deposit_ids = {}
+local active_dialog = nil
+local active_section = nil
+
+-- ─── Helpers ──────────────────────────────────────────────
+
+local function detect_split(obj, sec)
+    if obj:is_ammo() then return "ammo", obj:ammo_get_count() end
+    if sec ~= "itm_artefactskit" and IsItem("multiuse", sec) then return "multiuse", obj:get_remaining_uses() end
+    return nil, 1
+end
+
+local function compare_by_quality(a, b)
+    if a.condition ~= b.condition then
+        return a.condition > b.condition
+    end
+    return a.units > b.units
+end
+
+-- ─── Save / Load ────────────────────────────────────────────
+
+local function save_state(mdata)
+    mdata.sp_favorite_limits = favorite_limits
+end
+
+local function load_state(mdata)
+    favorite_limits = mdata.sp_favorite_limits or mdata.mine_favorite_limits or {}
+end
+
+-- ─── Put All Override ───────────────────────────────────────
+-- Our script loads after SortingPlus (zzzz_ > zzz_), so this
+-- wraps SortingPlus's override which wraps the original.
+-- We read PUTALL directly from the MCM module during callbacks.
+
+local SP_LMode_PutAll = ui_inventory.UIInventory.LMode_PutAll
+
+function ui_inventory.UIInventory:LMode_PutAll()
+    deposit_ids = {}
+
+    -- Pre-scan: group favorited items by section (only limited sections)
+    local groups = {} -- groups[section] = list of {id, condition, units, split_type}
+    db.actor:iterate_inventory(function(owner, obj)
+        local sec = obj:section()
+        if not zzz_rax_sortingplus_mcm.is_favorite(sec) then return end
+        local limit = favorite_limits[sec]
+        if not limit then return end
+        if not groups[sec] then groups[sec] = {} end
+        local split_type, units = detect_split(obj, sec)
+        table.insert(groups[sec], {
+            id = obj:id(),
+            condition = obj:condition(),
+            units = units,
+            split_type = split_type,
+        })
+    end)
+
+    -- For each limited section, keep best items greedily
+    local splits = {} -- items to split: {id, section, keep_units, excess_units, split_type}
+    for sec, items in pairs(groups) do
+        local limit = favorite_limits[sec]
+        table.sort(items, compare_by_quality)
+        -- Accumulate units; once we hit the limit, mark the rest for deposit
+        local acc = 0
+        local satisfied = false
+        for i = 1, #items do
+            if satisfied then
+                deposit_ids[items[i].id] = true
+            else
+                local prev_acc = acc
+                acc = acc + items[i].units
+                if acc >= limit then
+                    satisfied = true
+                    local needed = limit - prev_acc
+                    if needed == 0 then
+                        -- Keep none of this item — deposit whole, no split needed
+                        deposit_ids[items[i].id] = true
+                    elseif needed < items[i].units and items[i].split_type then
+                        -- Item straddles the limit — deposit and record for splitting
+                        deposit_ids[items[i].id] = true
+                        splits[#splits + 1] = {
+                            id = items[i].id,
+                            section = sec,
+                            keep_units = needed,
+                            excess_units = items[i].units - needed,
+                            split_type = items[i].split_type,
+                        }
+                    end
+                end
+            end
+        end
+        -- If total units < limit, deposit nothing (keep all)
+    end
+
+    SP_LMode_PutAll(self)
+
+    -- Split border items: item was moved to container by Put All above.
+    -- Trim container copy to excess, create kept portion back on player.
+    -- If Put All's weight check blocked the move, item is still on player — skip split.
+    for _, s in ipairs(splits) do
+        local obj = level.object_by_id(s.id)
+        if obj and not db.actor:object(s.id) then
+            -- Item is in the container (move succeeded) — split it
+            if s.split_type == "ammo" then
+                obj:ammo_set_count(s.excess_units)
+                alife_create_item(s.section, db.actor, {ammo = s.keep_units})
+            else -- multiuse
+                obj:set_remaining_uses(s.excess_units)
+                alife_create_item(s.section, db.actor, {uses = s.keep_units})
+            end
+        end
+        -- If item is still on player (move was blocked), no split needed — keep all
+    end
+
+    deposit_ids = {}
+end
+
+function ActorMenu_on_item_before_move(flags, npc_id, obj, mode, bag)
+    if not zzz_rax_sortingplus_mcm.PUTALL then return end
+    if flags.ret_value then return end
+    -- Only override if the block came from SortingPlus's favorite check.
+    -- If an earlier callback (e.g. stash capacity) already blocked the move, respect it.
+    if not zzz_rax_sortingplus_mcm.get_pre_sp_ret() then return end
+    if deposit_ids[obj:id()] then
+        flags.ret_value = true -- allow deposit of this excess item
+    end
+end
+
+-- ─── Input Dialog ───────────────────────────────────────────
+
+class "UIKeepLimitDialog" (CUIScriptWnd)
+
+function UIKeepLimitDialog:__init() super()
+    self:SetWndRect(Frect():set(0, 0, 1024, 768))
+    self:SetAutoDelete(true)
+
+    local xml = CScriptXmlInit()
+    xml:ParseFile("ui_sp_keepcaps.xml")
+
+    self.dialog = xml:InitStatic("dialog", self)
+    xml:InitStatic("dialog:background", self.dialog)
+    xml:InitStatic("dialog:title", self.dialog)
+
+    self.input = xml:InitEditBox("dialog:input", self.dialog)
+    self:Register(self.input, "fld_input")
+
+    local btn
+    btn = xml:Init3tButton("dialog:btn_ok", self.dialog)
+    self:Register(btn, "btn_ok")
+
+    btn = xml:Init3tButton("dialog:btn_all", self.dialog)
+    self:Register(btn, "btn_all")
+
+    btn = xml:Init3tButton("dialog:btn_cancel", self.dialog)
+    self:Register(btn, "btn_cancel")
+
+    self:AddCallback("btn_ok", ui_events.BUTTON_CLICKED, self.OnOK, self)
+    self:AddCallback("btn_all", ui_events.BUTTON_CLICKED, self.OnAll, self)
+    self:AddCallback("btn_cancel", ui_events.BUTTON_CLICKED, self.OnCancel, self)
+end
+
+function UIKeepLimitDialog:Open(sec, current)
+    active_section = sec
+    if current then
+        self.input:SetText(tostring(current))
+    else
+        self.input:SetText("")
+    end
+    self:ShowDialog(true)
+end
+
+function UIKeepLimitDialog:OnOK()
+    local text = self.input:GetText()
+    local num = tonumber(text)
+    if num and num >= 0 then
+        favorite_limits[active_section] = math.floor(num)
+    elseif text == "" then
+        favorite_limits[active_section] = nil
+    end
+    self:Close()
+end
+
+function UIKeepLimitDialog:OnAll()
+    favorite_limits[active_section] = nil
+    self:Close()
+end
+
+function UIKeepLimitDialog:OnCancel()
+    self:Close()
+end
+
+function UIKeepLimitDialog:Close()
+    self:HideDialog()
+    active_dialog = nil
+    active_section = nil
+end
+
+function UIKeepLimitDialog:OnKeyboard(dik, keyboard_action)
+    local res = CUIScriptWnd.OnKeyboard(self, dik, keyboard_action)
+    if res == false then
+        if keyboard_action == ui_events.WINDOW_KEY_PRESSED then
+            if dik == DIK_keys.DIK_ESCAPE then
+                self:Close()
+            elseif dik == DIK_keys.DIK_RETURN then
+                self:OnOK()
+            end
+        end
+    end
+    return res
+end
+
+-- ─── Context Menu ───────────────────────────────────────────
+
+function limit_menu_string(obj)
+    local sec = obj:section()
+    local limit = favorite_limits[sec]
+    local label = game.translate_string("st_sp_keep_limit")
+    if limit then
+        return label .. ": " .. tostring(limit)
+    else
+        return label .. ": " .. game.translate_string("st_sp_keep_all")
+    end
+end
+
+function limit_menu_precond(obj, bag, mode)
+    if mode == "repair" then return false end
+    return zzz_rax_sortingplus_mcm.is_favorite(obj:section())
+end
+
+function limit_menu_action(obj)
+    local sec = obj:section()
+    active_dialog = UIKeepLimitDialog()
+    active_dialog:Open(sec, favorite_limits[sec])
+end
+
+-- ─── Stock Up Button ──────────────────────────────────────
+-- Monkey-patch InitControls to shrink Take All and add Stock Up beside it.
+
+local orig_InitControls = ui_inventory.UIInventory.InitControls
+function ui_inventory.UIInventory:InitControls()
+    orig_InitControls(self)
+    -- Shrink Take All to make room
+    self.npc_takeall:SetWndSize(vector2():set(90, 24))
+    -- Create Stock Up button from dialog XML (no texture, matching Take All style)
+    self.sp_stockup_xml = CScriptXmlInit()
+    self.sp_stockup_xml:ParseFile("ui_sp_keepcaps.xml")
+    self.sp_stockup = self.sp_stockup_xml:Init3tButton("stockup_button", self.npc_dialog)
+    self.sp_stockup:SetWndPos(vector2():set(105, 736))
+    self:Register(self.sp_stockup, "stock_up")
+end
+
+local orig_InitCallbacks = ui_inventory.UIInventory.InitCallbacks
+function ui_inventory.UIInventory:InitCallbacks()
+    orig_InitCallbacks(self)
+    self:AddCallback("stock_up", ui_events.BUTTON_CLICKED, self.LMode_StockUp, self)
+end
+
+local orig_Reset = ui_inventory.UIInventory.Reset
+function ui_inventory.UIInventory:Reset(obj)
+    orig_Reset(self, obj)
+    if self.sp_stockup then
+        self.sp_stockup:Show(self.mode == "loot" and self.npc_is_box)
+    end
+end
+
+-- ─── Stock Up Logic ───────────────────────────────────────
+-- Inverse of Put All: take favorited items from container to fill up to keep limits.
+
+function ui_inventory.UIInventory:LMode_StockUp()
+    local npc = self:GetPartner()
+    if not npc then return end
+
+    local cc = self.CC["npc_bag"]
+    if not cc then return end
+
+    -- Step 1: count player units for each favorited+limited section
+    local player_counts = {}
+    db.actor:iterate_inventory(function(owner, obj)
+        local sec = obj:section()
+        if not zzz_rax_sortingplus_mcm.is_favorite(sec) then return end
+        if not favorite_limits[sec] then return end
+        local _, units = detect_split(obj, sec)
+        player_counts[sec] = (player_counts[sec] or 0) + units
+    end)
+
+    -- Step 2: calculate deficits
+    local deficits = {}
+    for sec, limit in pairs(favorite_limits) do
+        if zzz_rax_sortingplus_mcm.is_favorite(sec) then
+            local have = player_counts[sec] or 0
+            if have < limit then
+                deficits[sec] = limit - have
+            end
+        end
+    end
+    if not next(deficits) then return end
+
+    -- Step 3: scan container for matching items
+    local container_items = {}
+    for id, idx in pairs(cc.indx_id) do
+        local obj = level.object_by_id(id)
+        if obj then
+            local sec = obj:section()
+            if deficits[sec] then
+                local split_type, units = detect_split(obj, sec)
+                if not container_items[sec] then container_items[sec] = {} end
+                table.insert(container_items[sec], {
+                    id = id,
+                    condition = obj:condition(),
+                    units = units,
+                    split_type = split_type,
+                })
+            end
+        end
+    end
+
+    -- Step 4: take items greedily, best condition first
+    for sec, items in pairs(container_items) do
+        local remaining = deficits[sec]
+        if remaining and remaining > 0 then
+            table.sort(items, compare_by_quality)
+            for _, item in ipairs(items) do
+                if remaining <= 0 then break end
+                local obj = level.object_by_id(item.id)
+                if obj and self:Cond_Move(obj, "npc_bag") then
+                    if item.units <= remaining then
+                        -- Take whole item
+                        self:Action_Move(obj, "npc_bag")
+                        remaining = remaining - item.units
+                    elseif item.split_type then
+                        -- Take whole, then split: keep needed on player, return remainder
+                        local take_units = remaining
+                        self:Action_Move(obj, "npc_bag")
+                        obj = level.object_by_id(item.id)
+                        if obj and db.actor:object(item.id) then
+                            -- Move succeeded (item is now on player) — split it
+                            if item.split_type == "ammo" then
+                                obj:ammo_set_count(take_units)
+                                alife_create_item(sec, npc, {ammo = item.units - take_units})
+                            else -- multiuse
+                                obj:set_remaining_uses(take_units)
+                                alife_create_item(sec, npc, {uses = item.units - take_units})
+                            end
+                        end
+                        remaining = 0
+                    else
+                        -- Non-splittable (units=1): take if deficit remains
+                        self:Action_Move(obj, "npc_bag")
+                        remaining = remaining - item.units
+                    end
+                end
+            end
+        end
+    end
+
+    self.update_info = true
+end
+
+-- ─── Getters / Setters ──────────────────────────────────────
+
+function get_limit(sec)
+    return favorite_limits[sec]
+end
+
+function set_limit(sec, val)
+    favorite_limits[sec] = val
+end
+
+-- ─── Init ───────────────────────────────────────────────────
+
+function on_game_start()
+    RegisterScriptCallback("save_state", save_state)
+    RegisterScriptCallback("load_state", load_state)
+    RegisterScriptCallback("ActorMenu_on_item_before_move", ActorMenu_on_item_before_move)
+    rax_dynamic_custom_functor.add_functor("sp_keep_limit", limit_menu_string, limit_menu_precond, limit_menu_action)
+end


### PR DESCRIPTION
## What this adds

A few features I wanted for my own playthrough that might be useful to others.

### Keep limits
You can right-click a favorited item and set how many to keep. Put All deposits the rest — splits ammo stacks and multiuse items at the boundary. Limits persist across saves.

### Stock Up
A button next to Take All on stash containers. Pulls favorited items from the container to fill up to your keep limits. Basically the inverse of Put All.

### Favorites group by kind
MCM toggle. Favorites still pin to the top, but weapons stay with weapons, food with food, etc. instead of one flat block.

### Per-kind MCM controls
Each kind gets its own number input under group headers instead of the combined category sliders. Decimal values work for within-row ordering (2.1 before 2.2), with a toggle to turn that off.

### Sort tweaks
- `i_part` auto-splits into weapon/armor/general parts by section prefix
- New `w_ammo_parts` kind for bullets, casings, powder
- 350+ within-kind sort priorities so items show up in a consistent order
- Unknown kinds get auto-discovered and show up in a "Discovered" MCM group

### Other bits
- Adding new kinds/groups is data-driven now (LTX + XML, no script changes) — wrote it up in DEV.md
- Fixed a few global variable leaks
- Cleaned up some duplicated sort logic into shared helpers

## New files

| File | Purpose |
|------|---------|
| `zzzz_rax_sortingplus_keepcaps.script` | Keep limits, Put All override, Stock Up |
| `ui_sp_keepcaps.xml` | Dialog layout and Stock Up button |
| `ui_st_sp_keepcaps.xml` (eng/rus) | Strings for the above |
| `DEV.md` | Architecture notes, how to add new kinds/groups |

## Testing

- MCM loads with all group headers and per-kind inputs
- Keep limit + Put All splits ammo and multiuse items correctly
- Stock Up fills deficits, splits at boundary
- Favorites grouping toggle works
- Within-row priority toggle works
- Keep limits survive save/load